### PR TITLE
Corrigir rollback de algumas migrações

### DIFF
--- a/database/migrations/2020_04_17_153305_create_users_perfis_table.php
+++ b/database/migrations/2020_04_17_153305_create_users_perfis_table.php
@@ -28,10 +28,6 @@ class CreateUsersPerfisTable extends Migration
      */
     public function down()
     {
-        Schema::table('users', function (Blueprint $table) {
-            $table->dropForeign(['user_id', 'perfil_id']);
-        });
-
         Schema::dropIfExists('users_perfis');
     }
 }

--- a/database/migrations/2020_04_17_154753_add_pessoa_to_users_table.php
+++ b/database/migrations/2020_04_17_154753_add_pessoa_to_users_table.php
@@ -27,7 +27,8 @@ class AddPessoaToUsersTable extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropForeign('pessoa_id');
+            $table->dropForeign('users_pessoa_id_foreign');
+            $table->dropColumn('pessoa_id');
         });
     }
 }

--- a/database/migrations/2020_04_17_155043_add_tipo_pessoa_to_pessoas_table.php
+++ b/database/migrations/2020_04_17_155043_add_tipo_pessoa_to_pessoas_table.php
@@ -27,7 +27,8 @@ class AddTipoPessoaToPessoasTable extends Migration
     public function down()
     {
         Schema::table('pessoas', function (Blueprint $table) {
-            $table->dropForeign('tipo_pessoa_id');
+            $table->dropForeign('pessoas_tipo_pessoa_id_foreign');
+            $table->dropColumn('tipo_pessoa_id');
         });
     }
 }


### PR DESCRIPTION
## Mudanças

- Corrigir nome de chaves estrangeiras que estavam incorretas, o que
causava um erro na hora de dar um rollback nas migrações, ou na hora de
rodar o db:seed.

- Remover no rollback as colunas que foram adicionadas na migração, para
manter um estado consistente do banco de dados.

## Como testar

- Levantar os containers do projeto (`make up-dev`);
- Acessar o container do Laravel (`make shell`);
- Executar as migrações: `./artisan migrate`
- Executar os rollbacks: `./artisan migrate:rollback`

Resultado esperado: todas as migrações e rollbacks ocorrerem sem erro.