### PR TITLE
CRUD de instituições parceiras

### DIFF
--- a/app/Helpers/ApiError.php
+++ b/app/Helpers/ApiError.php
@@ -4,6 +4,7 @@ namespace App\Helpers;
 
 class ApiError
 {
+    const CODIGO_ERRO_INESPERADO = 1;
     const CODIGO_ERRO_CPF_CNPJ_NAO_ENCONTRADO = 100;
     const CODIGO_ERRO_SALVAR_PARCEIRO = 101;
     const CODIGO_ERRO_SALVAR_TIPO_PESSOA = 102;
@@ -16,6 +17,14 @@ class ApiError
     const CODIGO_ERRO_ATUALIZAR_TIPO_PESSOA = 109;
     const CODIGO_ERRO_REMOVER_PARCEIRO = 110;
     const CODIGO_ERRO_REMOVER_TIPO_PESSOA = 111;
+
+    public static function erroInesperado(string $message)
+    {
+        return self::setMessageAndCode(
+            'Um erro inesperado ocorreu: ' . $message,
+            self::CODIGO_ERRO_INESPERADO,
+        );
+    }
 
     public static function cpfCnpjNaoEncontrado()
     {
@@ -115,11 +124,6 @@ class ApiError
 
     private static function setMessageAndCode($message, $code)
     {
-        return [
-            'error' => [
-                'message' => $message,
-                'code' => $code,
-            ],
-        ];
+        return 'Erro #' . $code . ': ' . $message;
     }
 }

--- a/app/Helpers/ApiError.php
+++ b/app/Helpers/ApiError.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Helpers;
+
+class ApiError
+{
+    const CODIGO_ERRO_CPF_CNPJ_NAO_ENCONTRADO = 100;
+    const CODIGO_ERRO_SALVAR_PARCEIRO = 101;
+    const CODIGO_ERRO_SALVAR_TIPO_PESSOA = 102;
+    const CODIGO_ERRO_SALVAR_ENDERECO = 103;
+    const CODIGO_ERRO_SALVAR_TELEFONE = 104;
+
+    public static function cpfCnpjNaoEncontrado()
+    {
+        return self::setMessageAndCode(
+            'CPF ou CNPJ devem ser fornecidos',
+            self::CODIGO_ERRO_CPF_CNPJ_NAO_ENCONTRADO,
+        );
+    }
+
+    public static function falhaSalvarParceiro()
+    {
+        return self::setMessageAndCode(
+            'Não foi possível criar o parceiro',
+            self::CODIGO_ERRO_SALVAR_PARCEIRO,
+        );
+    }
+
+    public static function falhaSalvarTipoPessoa()
+    {
+        return self::setMessageAndCode(
+            'Não foi possível criar o tipo pessoa',
+            self::CODIGO_ERRO_SALVAR_TIPO_PESSOA,
+        );
+    }
+
+    public static function falhaSalvarEndereco()
+    {
+        return self::setMessageAndCode(
+            'Não foi possível criar o endereco',
+            self::CODIGO_ERRO_SALVAR_ENDERECO,
+        );
+    }
+
+    public static function falhaSalvarTelefone()
+    {
+        return self::setMessageAndCode(
+            'Não foi possível criar o telefone',
+            self::CODIGO_ERRO_SALVAR_TELEFONE,
+        );
+    }
+
+    private static function setMessageAndCode($message, $code)
+    {
+        return [
+            'error' => [
+                'message' => $message,
+                'code' => $code,
+            ],
+        ];
+    }
+}

--- a/app/Helpers/ApiError.php
+++ b/app/Helpers/ApiError.php
@@ -14,6 +14,8 @@ class ApiError
     const CODIGO_ERRO_REMOVER_TELEFONE = 107;
     const CODIGO_ERRO_ATUALIZAR_PARCEIRO = 108;
     const CODIGO_ERRO_ATUALIZAR_TIPO_PESSOA = 109;
+    const CODIGO_ERRO_REMOVER_PARCEIRO = 110;
+    const CODIGO_ERRO_REMOVER_TIPO_PESSOA = 111;
 
     public static function cpfCnpjNaoEncontrado()
     {
@@ -92,6 +94,22 @@ class ApiError
         return self::setMessageAndCode(
             'Falha ao atualizar o tipo_pessoa ' . $tipoPessoaId,
             self::CODIGO_ERRO_ATUALIZAR_TIPO_PESSOA,
+        );
+    }
+
+    public static function falhaRemoverParceiro()
+    {
+        return self::setMessageAndCode(
+            'Falha ao remover o endereco do parceiro',
+            self::CODIGO_ERRO_REMOVER_PARCEIRO,
+        );
+    }
+
+    public static function falhaRemoverTipoPessoa()
+    {
+        return self::setMessageAndCode(
+            'Falha ao remover o endereco do parceiro',
+            self::CODIGO_ERRO_REMOVER_TIPO_PESSOA,
         );
     }
 

--- a/app/Helpers/ApiError.php
+++ b/app/Helpers/ApiError.php
@@ -9,6 +9,11 @@ class ApiError
     const CODIGO_ERRO_SALVAR_TIPO_PESSOA = 102;
     const CODIGO_ERRO_SALVAR_ENDERECO = 103;
     const CODIGO_ERRO_SALVAR_TELEFONE = 104;
+    const CODIGO_ERRO_PARCEIRO_NAO_ENCONTRADO = 105;
+    const CODIGO_ERRO_REMOVER_ENDERECO = 106;
+    const CODIGO_ERRO_REMOVER_TELEFONE = 107;
+    const CODIGO_ERRO_ATUALIZAR_PARCEIRO = 108;
+    const CODIGO_ERRO_ATUALIZAR_TIPO_PESSOA = 109;
 
     public static function cpfCnpjNaoEncontrado()
     {
@@ -47,6 +52,46 @@ class ApiError
         return self::setMessageAndCode(
             'Não foi possível criar o telefone',
             self::CODIGO_ERRO_SALVAR_TELEFONE,
+        );
+    }
+
+    public static function parceiroNaoEncontrado($parceiroId)
+    {
+        return self::setMessageAndCode(
+            'Parceiro ' . $parceiroId . ' não encontrado.',
+            self::CODIGO_ERRO_PARCEIRO_NAO_ENCONTRADO,
+        );
+    }
+
+    public static function falhaRemoverEndereco()
+    {
+        return self::setMessageAndCode(
+            'Falha ao remover o endereco do parceiro',
+            self::CODIGO_ERRO_REMOVER_ENDERECO,
+        );
+    }
+
+    public static function falhaRemoverTelefone()
+    {
+        return self::setMessageAndCode(
+            'Falha ao remover o telefone do parceiro',
+            self::CODIGO_ERRO_REMOVER_TELEFONE,
+        );
+    }
+
+    public static function falhaAtualizarParceiro($parceiroId)
+    {
+        return self::setMessageAndCode(
+            'Falha ao atualizar o parceiro ' . $parceiroId,
+            self::CODIGO_ERRO_ATUALIZAR_PARCEIRO,
+        );
+    }
+
+    public static function falhaAtualizarTipoPessoa($tipoPessoaId)
+    {
+        return self::setMessageAndCode(
+            'Falha ao atualizar o tipo_pessoa ' . $tipoPessoaId,
+            self::CODIGO_ERRO_ATUALIZAR_TIPO_PESSOA,
         );
     }
 

--- a/app/Helpers/HttpStatus.php
+++ b/app/Helpers/HttpStatus.php
@@ -21,7 +21,6 @@ class HttpStatus
     const USE_PROXY = 305;
     const UNUSED = 306;
     const TEMPORARY_REDIRECT = 307;
-    const CodesBeginAt = 400;
     const BAD_REQUEST = 400;
     const UNAUTHORIZED = 401;
     const PAYMENT_REQUIRED = 402;

--- a/app/Helpers/HttpStatus.php
+++ b/app/Helpers/HttpStatus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Helpers;
+
+class HttpStatus
+{
+    const CONTINUE = 100;
+    const SWITCHING_PROTOCOLS = 101;
+    const OK = 200;
+    const CREATED = 201;
+    const ACCEPTED = 202;
+    const NONAUTHORITATIVE_INFORMATION = 203;
+    const NO_CONTENT = 204;
+    const RESET_CONTENT = 205;
+    const PARTIAL_CONTENT = 206;
+    const MULTIPLE_CHOICES = 300;
+    const MOVED_PERMANENTLY = 301;
+    const FOUND = 302;
+    const SEE_OTHER = 303;
+    const NOT_MODIFIED = 304;
+    const USE_PROXY = 305;
+    const UNUSED = 306;
+    const TEMPORARY_REDIRECT = 307;
+    const CodesBeginAt = 400;
+    const BAD_REQUEST = 400;
+    const UNAUTHORIZED = 401;
+    const PAYMENT_REQUIRED = 402;
+    const FORBIDDEN = 403;
+    const NOT_FOUND = 404;
+    const METHOD_NOT_ALLOWED = 405;
+    const NOT_ACCEPTABLE = 406;
+    const PROXY_AUTHENTICATION_REQUIRED = 407;
+    const REQUEST_TIMEOUT = 408;
+    const CONFLICT = 409;
+    const GONE = 410;
+    const LENGTH_REQUIRED = 411;
+    const PRECONDITION_FAILED = 412;
+    const REQUEST_ENTITY_TOO_LARGE = 413;
+    const REQUEST_URI_TOO_LONG = 414;
+    const UNSUPPORTED_MEDIA_TYPE = 415;
+    const REQUESTED_RANGE_NOT_SATISFIABLE = 416;
+    const EXPECTATION_FAILED = 417;
+    const INTERNAL_SERVER_ERROR = 500;
+    const NOT_IMPLEMENTED = 501;
+    const BAD_GATEWAY = 502;
+    const SERVICE_UNAVAILABLE = 503;
+    const GATEWAY_TIMEOUT = 504;
+    const VERSION_NOT_SUPPORTED = 505;
+}

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -27,11 +27,15 @@ class ParceiroController extends Controller
         return response()->json($data);
     }
 
-    public function find(Parceiro $id)
+    public function find(Request $request, string $id)
     {
-        $data = ['data' => $id];
+        $resultado = $this->parceiroService->find($id);
+        if ($resultado['success']) {
+            $dado = ['data' => $resultado['data']];
+            return response()->json($dado, $resultado['code']);
+        }
 
-        return response()->json($data);
+        return response()->json($resultado['message'], $resultado['code']);
     }
 
     public function store(Request $request)

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-use App\Models\Parceiro;
 use Illuminate\Http\Request;
+use App\Models\Parceiro;
+use App\Services\ParceiroService;
 
 class ParceiroController extends Controller
 {
     const PARCEIROS_POR_PAGINA = 6;
 
+    private ParceiroService $parceiroService;
+
     public function __construct(Parceiro $parceiro)
     {
         $this->parceiro = $parceiro;
+        $this->parceiroService = new ParceiroService();
     }
 
     public function get()
@@ -28,5 +32,17 @@ class ParceiroController extends Controller
         $data = ['data' => $id];
 
         return response()->json($data);
+    }
+
+    public function store(Request $request)
+    {
+        $resultado = $this->parceiroService->create($request);
+
+        if ($resultado['success']) {
+            $dado = ['data' => ['id' => $resultado['data']->id]];
+            return response()->json($dado, $resultado['code']);
+        }
+
+        return response()->json($resultado['message'], $resultado['code']);
     }
 }

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -45,4 +45,16 @@ class ParceiroController extends Controller
 
         return response()->json($resultado['message'], $resultado['code']);
     }
+
+    public function update(Request $request, string $id)
+    {
+        $resultado = $this->parceiroService->update($request, $id);
+
+        if ($resultado['success']) {
+            $dado = ['data' => null];
+            return response()->json($dado, $resultado['code']);
+        }
+
+        return response()->json($resultado['message'], $resultado['code']);
+    }
 }

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -61,4 +61,16 @@ class ParceiroController extends Controller
 
         return response()->json($resultado['message'], $resultado['code']);
     }
+
+    public function delete(Request $request, string $id)
+    {
+        $resultado = $this->parceiroService->delete($request, $id);
+
+        if ($resultado['success']) {
+            $dado = ['data' => null];
+            return response()->json($dado, $resultado['code']);
+        }
+
+        return response()->json($resultado['message'], $resultado['code']);
+    }
 }

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Parceiro;
+use Illuminate\Http\Request;
+
+class ParceiroController extends Controller
+{
+    const PARCEIROS_POR_PAGINA = 6;
+
+    public function __construct(Parceiro $parceiro)
+    {
+        $this->parceiro = $parceiro;
+    }
+
+    public function get()
+    {
+        $data = $this->parceiro->paginate(self::PARCEIROS_POR_PAGINA);
+
+        return response()->json($data);
+    }
+
+    public function find(Parceiro $id)
+    {
+        $data = ['data' => $id];
+
+        return response()->json($data);
+    }
+}

--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -4,73 +4,193 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use App\Models\Parceiro;
+use App\Http\Requests\Parceiro\AtualizarParceiroRequest;
+use App\Http\Requests\Parceiro\CriarParceiroRequest;
+use App\Http\Resources\Parceiro\ParceiroResource;
 use App\Services\ParceiroService;
 
+/**
+ * @group ParceiroController
+ *
+ * Controller responsável pelo CRUD de instituições parceiras.
+ */
 class ParceiroController extends Controller
 {
-    const PARCEIROS_POR_PAGINA = 6;
-
+    /**
+     * @var ParceiroService
+     */
     private ParceiroService $parceiroService;
 
-    public function __construct(Parceiro $parceiro)
+    /**
+     * ParceiroController constructor.
+     * @param ParceiroService $parceiroService
+     */
+    public function __construct(ParceiroService $parceiroService)
     {
-        $this->parceiro = $parceiro;
-        $this->parceiroService = new ParceiroService();
+        $this->middleware(['auth:api', 'validarToken']);
+
+        $this->parceiroService = $parceiroService;
     }
 
-    public function get()
+    /**
+     * Listar
+     *
+     * Endpoint para buscar uma lista de parceiros.
+     *
+     * @authenticated
+     *
+     * @queryParam page Número da página para retornar os dados. Example: "1"
+     * @queryParam limit Total de elementos por página para retornar. Example: "6"
+     *
+     * @responseFile 200 responses/ParceiroController/get.200.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function get(Request $request): JsonResponse
     {
-        $data = $this->parceiro->paginate(self::PARCEIROS_POR_PAGINA);
+        $resultado = $this->parceiroService->get($request);
 
-        return response()->json($data);
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
+
+        return $resource->response()->setStatusCode($resultado['code']);
     }
 
-    public function find(Request $request, string $id)
+    /**
+     * Buscar
+     *
+     * Endpoint para obter os dados de um parceiro específico.
+     *
+     * @authenticated
+     *
+     * @urlParam parceiro required ID do parceiro. Example: 1
+     *
+     * @responseFile 200 responses/ParceiroController/show.200.json
+     * @responseFile 401 responses/Middleware/unauthorized.401.json
+     * @responseFile 404 responses/ParceiroController/show.404.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function find(Request $request, string $id): JsonResponse
     {
         $resultado = $this->parceiroService->find($id);
-        if ($resultado['success']) {
-            $dado = ['data' => $resultado['data']];
-            return response()->json($dado, $resultado['code']);
-        }
 
-        return response()->json($resultado['message'], $resultado['code']);
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
+
+        return $resource->response()->setStatusCode($resultado['code']);
     }
 
-    public function store(Request $request)
+    /**
+     * Criar
+     *
+     * Endpoint para inserir uma nova instituição parceira no sistema.
+     *
+     * @authenticated
+     *
+     * @bodyParam nome string required Nome do novo parceiro - (max. 255). Example: Manaus+Humana
+     * @bodyParam email string required Endereço de e-mail do parceiro - (max. 255). Example: fulano@tal.com
+     * @bodyParam cnpj string Número do CNPJ da instituição (obrigatório se não houver CPF). Example: 13245678901234
+     * @bodyParam cpf string Número do CPF da instituição (obrigatório se não houver CNPJ). Example: 12345678901
+     * @bodyParam telefones array required Lista de telefones.
+     * @bodyParam telefones[0].telefone int required Número de telefone com DDD. Example: 92991234567
+     * @bodyParam telefones[0].tipo string required Tipo do telefone: "Fixo" ou "Celular"
+     * @bodyParam enderecos array required Lista de enderecos.
+     * @bodyParam enderecos[0].endereco string required Nome da rua, com número e complemento. Example: Rua da paz, 150
+     * @bodyParam enderecos[0].bairro_id int required ID do bairro. Example: 1
+     * @bodyParam enderecos[0].cep string required CEP da rua. Example: "69061000"
+     * @bodyParam enderecos[0].ponto_referencia string Ponto de referência. Example: "INPA"
+     * @bodyParam enderecos[0].cidade_id int required ID da cidade. Example: 1
+     *
+     * @responseFile 201 responses/ParceiroController/store.201.json
+     * @responseFile 401 responses/Middleware/unauthorized.401.json
+     * @responseFile 422 responses/ParceiroController/store.422.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function store(CriarParceiroRequest $request): JsonResponse
     {
         $resultado = $this->parceiroService->create($request);
 
-        if ($resultado['success']) {
-            $dado = ['data' => ['id' => $resultado['data']->id]];
-            return response()->json($dado, $resultado['code']);
-        }
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
 
-        return response()->json($resultado['message'], $resultado['code']);
+        return $resource->response()->setStatusCode($resultado['code']);
     }
 
-    public function update(Request $request, string $id)
+    /**
+     * Atualizar
+     *
+     * Endpoint para atualizar os dados de um parceiro.
+     *
+     * @authenticated
+     *
+     * @urlParam parceiro required ID do parceiro. Example: 1
+     * @bodyParam nome string required Nome do novo parceiro - (max. 255). Example: Manaus+Humana
+     * @bodyParam email string required Endereço de e-mail do parceiro - (max. 255). Example: fulano@tal.com
+     * @bodyParam cnpj string Número do CNPJ da instituição (obrigatório se não houver CPF). Example: 13245678901234
+     * @bodyParam cpf string Número do CPF da instituição (obrigatório se não houver CNPJ). Example: 12345678901
+     * @bodyParam telefones array required Lista de telefones.
+     * @bodyParam telefones[0].telefone int required Número de telefone com DDD. Example: 92991234567
+     * @bodyParam telefones[0].tipo string required Tipo do telefone: "Fixo" ou "Celular"
+     * @bodyParam enderecos array required Lista de enderecos
+     * @bodyParam enderecos[0].endereco string required Nome da rua, com número e complemento. Example: Rua da paz, 150
+     * @bodyParam enderecos[0].bairro_id int required ID do bairro. Example: 1
+     * @bodyParam enderecos[0].cep string required CEP da rua. Example: "69061000"
+     * @bodyParam enderecos[0].ponto_referencia string Ponto de referência. Example: "INPA"
+     * @bodyParam enderecos[0].cidade_id int required ID da cidade. Example: 1
+     *
+     * @responseFile 200 responses/ParceiroController/update.200.json
+     * @responseFile 401 responses/Middleware/unauthorized.401.json
+     * @responseFile 404 responses/ParceiroController/update.404.json
+     * @responseFile 422 responses/ParceiroController/update.422.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function update(AtualizarParceiroRequest $request, string $id): JsonResponse
     {
         $resultado = $this->parceiroService->update($request, $id);
 
-        if ($resultado['success']) {
-            $dado = ['data' => null];
-            return response()->json($dado, $resultado['code']);
-        }
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
 
-        return response()->json($resultado['message'], $resultado['code']);
+        return $resource->response()->setStatusCode($resultado['code']);
     }
 
-    public function delete(Request $request, string $id)
+    /**
+     * Remover
+     *
+     * Endpoint para remover um parceiro do sistema.
+     *
+     * @authenticated
+     *
+     * @urlParam parceiro required ID do parceiro. Example: 1
+     *
+     * @responseFile 200 responses/ParceiroController/delete.200.json
+     * @responseFile 401 responses/Middleware/unauthorized.401.json
+     * @responseFile 404 responses/ParceiroController/delete.404.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function delete(Request $request, string $id): JsonResponse
     {
         $resultado = $this->parceiroService->delete($request, $id);
 
-        if ($resultado['success']) {
-            $dado = ['data' => null];
-            return response()->json($dado, $resultado['code']);
-        }
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
 
-        return response()->json($resultado['message'], $resultado['code']);
+        return $resource->response()->setStatusCode($resultado['code']);
     }
 }

--- a/app/Http/Requests/Auth/CriarUsuarioRequest.php
+++ b/app/Http/Requests/Auth/CriarUsuarioRequest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Auth;
 
-use App\Http\Resources\FormRequest\FailedResource;
-use App\Traits\FormRequest as FormRequestTrait;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use App\Http\Resources\FormRequest\FailedResource;
+use App\Traits\FormRequest as FormRequestTrait;
 
 class CriarUsuarioRequest extends FormRequest
 {

--- a/app/Http/Requests/Parceiro/AtualizarParceiroRequest.php
+++ b/app/Http/Requests/Parceiro/AtualizarParceiroRequest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Parceiro;
+
+use App\Http\Resources\FormRequest\FailedResource;
+use App\Traits\FormRequest as FormRequestTrait;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class AtualizarParceiroRequest extends FormRequest
+{
+    use FormRequestTrait;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'nome' => 'required|min:2',
+            'email' => 'required|email',
+            'telefones' => 'required|array|min:1',
+            'telefones.*.tipo' => 'required|in:Celular,Fixo',
+            'enderecos' => 'required|array|min:1',
+            'enderecos.*.endereco' => 'required|max:255',
+            'enderecos.*.bairro_id' => 'required|exists:bairros,id',
+            'enderecos.*.ponto_referencia' => 'nullable',
+            'enderecos.*.cep' => 'required|digits:8',
+            'enderecos.*.cidade_id' => 'required|exists:cidades,id',
+        ];
+
+        $cpfRule = 'nullable';
+        $cnpjRule = 'nullable';
+        $telefoneRule = 'nullable';
+
+        if (!$this->validateCpfOrCnpjBelongsToId($this)) {
+            $cpfRule = 'required_without:cnpj|cpf|size:11|unique:tipos_pessoa,cpf_cnpj';
+            $cnpjRule = 'required_without:cpf|cnpj|size:14|unique:tipos_pessoa,cpf_cnpj';
+        }
+
+        if (!$this->validateTelefoneBelongsToId($this)) {
+            $telefoneRule = 'required|numeric|min:10|unique:telefones,telefone';
+        }
+
+        $rules['cpf'] = $cpfRule;
+        $rules['cnpj'] = $cnpjRule;
+        $rules['telefones.*.telefone'] = $telefoneRule;
+
+        return $rules;
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            "required" => "O :attribute é obrigatório.",
+            "required_without" => "O :attribute é obrigatório quando :values não foi informado.",
+            "min" => "O :attribute não pode ter menos que :min caracteres.",
+            "max" => "O :attribute não pode ter mais que :max caracteres.",
+            "email" => "O :attribute deve ser um endereço de e-mail válido.",
+            "in" => "O :attribute é inválido (aceito: :values).",
+            "cpf" => "O :attribute é inválido.",
+            "cnpj" => "O :attribute é inválido.",
+            "array" => "O :attribute deve ser um array.",
+            "numeric" => "O :attribute deve ser um numérico.",
+            "exists" => "O :attribute é inválido.",
+            "digits" => "O :attribute deve possuir somente números.",
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return [
+            'nome' => 'Nome',
+            'email' => 'Email',
+            'cpf' => 'CPF',
+            'cnpj' => 'CNPJ',
+            'telefones' => 'Telefone',
+            'telefones.*.telefone' => 'Número do Telefone',
+            'telefones.*.tipo' => 'Tipo do Telefone',
+            'enderecos' => 'Endereço',
+            'enderecos.*.endereco' => 'Endereço',
+            'enderecos.*.bairro_id' => 'ID do Bairro',
+            'enderecos.*.ponto_referencia' => 'Ponto de Referência',
+            'enderecos.*.cep' => 'CEP',
+            'enderecos.*.cidade_id' => 'ID da Cidade',
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->mergeExistsCpfOrCnpj($this);
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @param  Validator  $validator
+     * @return void
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        $failedResource = new FailedResource(
+            null,
+            false,
+            "Existem campos inválidos.",
+            $validator->errors()->unique(),
+        );
+
+        throw new HttpResponseException($failedResource->response()->setStatusCode(422));
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     */
+    public function failedAuthorization(): void
+    {
+        $failedResource = new FailedResource(null, false, "Está ação não é autorizada.");
+
+        throw new HttpResponseException($failedResource->response()->setStatusCode(403));
+    }
+}

--- a/app/Http/Requests/Parceiro/CriarParceiroRequest.php
+++ b/app/Http/Requests/Parceiro/CriarParceiroRequest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Parceiro;
+
+use App\Http\Resources\FormRequest\FailedResource;
+use App\Traits\FormRequest as FormRequestTrait;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class CriarParceiroRequest extends FormRequest
+{
+    use FormRequestTrait;
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'nome' => 'required|min:2',
+            'email' => 'required|email',
+            'cpf' => 'required_without:cnpj|cpf|size:11|unique:tipos_pessoa,cpf_cnpj',
+            'cnpj' => 'required_without:cpf|cnpj|size:14|unique:tipos_pessoa,cpf_cnpj',
+            'telefones' => 'required|array|min:1',
+            'telefones.*.telefone' => 'required|numeric|min:10|unique:telefones,telefone',
+            'telefones.*.tipo' => 'required|in:Celular,Fixo',
+            'enderecos' => 'required|array|min:1',
+            'enderecos.*.endereco' => 'required|max:255',
+            'enderecos.*.bairro_id' => 'required|exists:bairros,id',
+            'enderecos.*.ponto_referencia' => 'nullable',
+            'enderecos.*.cep' => 'required|digits:8',
+            'enderecos.*.cidade_id' => 'required|exists:cidades,id',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array
+     */
+    public function messages(): array
+    {
+        return [
+            "required" => "O :attribute é obrigatório.",
+            "required_without" => "O :attribute é obrigatório quando :values não foi informado.",
+            "min" => "O :attribute não pode ter menos que :min caracteres.",
+            "max" => "O :attribute não pode ter mais que :max caracteres.",
+            "email" => "O :attribute deve ser um endereço de e-mail válido.",
+            "in" => "O :attribute é inválido (aceito: :values).",
+            "cpf" => "O :attribute é inválido.",
+            "cnpj" => "O :attribute é inválido.",
+            "array" => "O :attribute deve ser um array.",
+            "numeric" => "O :attribute deve ser um numérico.",
+            "exists" => "O :attribute é inválido.",
+            "digits" => "O :attribute deve possuir somente números.",
+        ];
+    }
+
+    /**
+     * Get custom attributes for validator errors.
+     *
+     * @return array
+     */
+    public function attributes(): array
+    {
+        return [
+            'nome' => 'Nome',
+            'email' => 'Email',
+            'cpf' => 'CPF',
+            'cnpj' => 'CNPJ',
+            'telefones' => 'Telefone',
+            'telefones.*.telefone' => 'Número do Telefone',
+            'telefones.*.tipo' => 'Tipo do Telefone',
+            'enderecos' => 'Endereço',
+            'enderecos.*.endereco' => 'Endereço',
+            'enderecos.*.bairro_id' => 'ID do Bairro',
+            'enderecos.*.ponto_referencia' => 'Ponto de Referência',
+            'enderecos.*.cep' => 'CEP',
+            'enderecos.*.cidade_id' => 'ID da Cidade',
+        ];
+    }
+
+    /**
+     * Prepare the data for validation.
+     *
+     * @return void
+     */
+    protected function prepareForValidation()
+    {
+        $this->mergeExistsCpfOrCnpj($this);
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @param  Validator  $validator
+     * @return void
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        $failedResource = new FailedResource(
+            null,
+            false,
+            "Existem campos inválidos.",
+            $validator->errors()->unique(),
+        );
+
+        throw new HttpResponseException($failedResource->response()->setStatusCode(422));
+    }
+
+    /**
+     * Handle a failed authorization attempt.
+     *
+     * @return void
+     */
+    public function failedAuthorization(): void
+    {
+        $failedResource = new FailedResource(null, false, "Está ação não é autorizada.");
+
+        throw new HttpResponseException($failedResource->response()->setStatusCode(403));
+    }
+}

--- a/app/Http/Resources/Parceiro/ParceiroResource.php
+++ b/app/Http/Resources/Parceiro/ParceiroResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Parceiro;
+
+use App\Http\Resources\ResourceBase;
+
+class ParceiroResource extends ResourceBase
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource;
+    }
+}

--- a/app/Models/Bairro.php
+++ b/app/Models/Bairro.php
@@ -13,6 +13,12 @@ class Bairro extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'id',
+        'created_at',
+        'updated_at',
+        'cidade_id',
+    ];
 
     public function cidade()
     {

--- a/app/Models/Cidade.php
+++ b/app/Models/Cidade.php
@@ -13,6 +13,15 @@ class Cidade extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'id',
+        'estado_id',
+        'created_at',
+        'updated_at',
+    ];
+    protected $with = [
+        'estado',
+    ];
 
     public function estado()
     {

--- a/app/Models/Endereco.php
+++ b/app/Models/Endereco.php
@@ -13,6 +13,18 @@ class Endereco extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'bairro_id',
+        'parceiro_id',
+        'cidade_id',
+    ];
+    protected $with = [
+        'cidade',
+        'bairro',
+    ];
+
 
     public function cidade()
     {

--- a/app/Models/Estado.php
+++ b/app/Models/Estado.php
@@ -13,6 +13,11 @@ class Estado extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'id',
+        'created_at',
+        'updated_at',
+    ];
 
     public function cidades()
     {

--- a/app/Models/Parceiro.php
+++ b/app/Models/Parceiro.php
@@ -13,6 +13,16 @@ class Parceiro extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'tipo_pessoa_id',
+    ];
+    protected $with = [
+        'tipoPessoa',
+        'telefones',
+        'enderecos',
+    ];
 
     public function tipoPessoa()
     {

--- a/app/Models/Telefone.php
+++ b/app/Models/Telefone.php
@@ -30,9 +30,4 @@ class Telefone extends Model
     {
         return $this->belongsTo('App\Models\Parceiro', 'parceiro_id');
     }
-
-    public function getTipoAttribute($value)
-    {
-        return self::TIPO_TELEFONES[$value];
-    }
 }

--- a/app/Models/Telefone.php
+++ b/app/Models/Telefone.php
@@ -13,6 +13,11 @@ class Telefone extends Model
     protected $guarded = [
         'id',
     ];
+    protected $hidden = [
+        'created_at',
+        'updated_at',
+        'parceiro_id',
+    ];
 
     const TIPO_TELEFONE_CELULAR = 1;
     const TIPO_TELEFONE_FIXO = 2;
@@ -24,5 +29,10 @@ class Telefone extends Model
     public function parceiro()
     {
         return $this->belongsTo('App\Models\Parceiro', 'parceiro_id');
+    }
+
+    public function getTipoAttribute($value)
+    {
+        return self::TIPO_TELEFONES[$value];
     }
 }

--- a/app/Models/TipoPessoa.php
+++ b/app/Models/TipoPessoa.php
@@ -20,6 +20,9 @@ class TipoPessoa extends Model
         'created_at', 'updated_at'
     ];
 
+    const TIPO_PESSOA_PF = 'pf';
+    const TIPO_PESSOA_PJ = 'pj';
+
     const TIPO_PESSOA = [
         'pf' => 'PF',
         'pj' => 'PJ',

--- a/app/Services/ParceiroService.php
+++ b/app/Services/ParceiroService.php
@@ -35,6 +35,25 @@ class ParceiroService
         'enderecos.*.cidade_id' => 'required|exists:cidades,id',
     ];
 
+    public function find(string $parceiroId): array
+    {
+        $parceiro = Parceiro::find($parceiroId);
+        if (is_null($parceiro)) {
+            return [
+                'success' => false,
+                'message' => ApiError::parceiroNaoEncontrado($parceiroId),
+                'code' => HttpStatus::NOT_FOUND,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'data' => $parceiro,
+            'message' => 'Parceiro encontrado!',
+            'code' => HttpStatus::OK,
+        ];
+    }
+
     public function create(Request $request): array
     {
         $resultado = $this->validate($request);
@@ -76,14 +95,13 @@ class ParceiroService
 
     public function update(Request $request, string $parceiroId): array
     {
-        $parceiro = Parceiro::find($parceiroId);
-        if (is_null($parceiro)) {
-            return [
-                'success' => false,
-                'message' => ApiError::parceiroNaoEncontrado($parceiroId),
-                'code' => HttpStatus::NOT_FOUND,
-            ];
+        $resultado = $this->find($parceiroId);
+        if (!$resultado['success']) {
+            return $resultado;
         }
+
+        $parceiro = $resultado['data'];
+
         $resultado = $this->validate($request);
         if (!$resultado[0]) {
             return [

--- a/app/Services/ParceiroService.php
+++ b/app/Services/ParceiroService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Exception;
+use Throwable;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Helpers\ApiError;
+use App\Helpers\HttpStatus;
+use App\Models\Endereco;
+use App\Models\Parceiro;
+use App\Models\Telefone;
+use App\Models\TipoPessoa;
+use App\Services\EndercoService;
+use App\Services\TelefoneService;
+
+class ParceiroService
+{
+    private array $regrasValidacao = [
+        'nome' => 'required|min:2',
+        'email' => 'required|email',
+        'cpf' => 'nullable|digits:11',
+        'cnpj' => 'nullable|digits:14',
+        'telefones' => 'required|array|min:1',
+        'telefones.*.telefone' => 'required|numeric|min:10',
+        'telefones.*.tipo' => 'required|in:Celular,Fixo',
+        'enderecos' => 'required|array|min:1',
+        'enderecos.*.endereco' => 'required|max:255',
+        'enderecos.*.bairro_id' => 'required|exists:bairros,id',
+        'enderecos.*.ponto_referencia' => 'nullable',
+        'enderecos.*.cep' => 'required|digits:8',
+        'enderecos.*.cidade_id' => 'required|exists:cidades,id',
+    ];
+
+    public function create(Request $request): array
+    {
+        $resultado = $this->validate($request);
+        if (!$resultado[0]) {
+            return [
+                'success' => false,
+                'message' => $resultado[1],
+                'code' => HttpStatus::BAD_REQUEST,
+            ];
+        }
+
+        $dados = $resultado[1];
+        DB::beginTransaction();
+
+        try {
+            $tipoPessoa = $this->criarTipoPessoa($dados);
+            $parceiro = $this->criarParceiro($dados, $tipoPessoa);
+            $this->criarEndereco($dados, $parceiro);
+            $this->criarTelefone($dados, $parceiro);
+
+            DB::commit();
+
+            return [
+                'success' => true,
+                'data' => $parceiro,
+                'message' => 'Parceiro criada com sucesso!',
+                'code' => HttpStatus::CREATED,
+            ];
+        } catch (Throwable $e) {
+            DB::rollBack();
+
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+            ];
+        }
+    }
+
+    protected function validate(Request $request): array
+    {
+        $dadosValidados = $request->validate($this->regrasValidacao);
+
+        if (!isset($dadosValidados['cpf']) && !isset($dadosValidados['cnpj'])) {
+            return [false, ApiError::cpfCnpjNaoEncontrado()];
+        }
+
+        return [true, $dadosValidados];
+    }
+
+    private function criarParceiro(array $dados, TipoPessoa $tipoPessoa): Parceiro
+    {
+        $parceiro = Parceiro::create([
+            'nome' => $dados['nome'],
+            'email' => $dados['email'],
+            'tipo_pessoa_id' => $tipoPessoa->id,
+        ]);
+
+        throw_if(
+            !$parceiro,
+            Exception::class,
+            [ApiError::falhaSalvarParceiro(), HttpStatus::INTERNAL_SERVER_ERROR],
+        );
+
+        return $parceiro;
+    }
+
+    private function criarTipoPessoa(array $dados): TipoPessoa
+    {
+        $tipoPessoa = new TipoPessoa();
+        $tipoPessoa->tipo_pessoa = $this->getTipoPessoa($dados);
+        $tipoPessoa->cpf_cnpj = $this->getCpfOrCnpj($dados);
+        $resultado = $tipoPessoa->save();
+
+        throw_if(
+            !$resultado,
+            \Exception::class,
+            ApiError::falhaSalvarTipoPessoa(), HttpStatus::INTERNAL_SERVER_ERROR,
+        );
+
+        return $tipoPessoa;
+    }
+
+    private function getTipoPessoa(array $dados): string
+    {
+        if (isset($dados['cnpj'])) {
+            return TipoPessoa::TIPO_PESSOA_PJ;
+        }
+
+        return TipoPessoa::TIPO_PESSOA_PF;
+    }
+
+    private function getCpfOrCnpj(array $dados): string
+    {
+        if (isset($dados['cnpj'])) {
+            return $dados['cnpj'];
+        }
+
+        return $dados['cpf'];
+    }
+
+    private function criarEndereco(array $dados, Parceiro $parceiro)
+    {
+        foreach($dados['enderecos'] as $endereco) {
+            $endereco['parceiro_id'] = $parceiro->id;
+            $novoEndereco = Endereco::create($endereco);
+
+            throw_if(
+                !$novoEndereco,
+                Exception::class,
+                [ApiError::falhaSalvarEndereco(), HttpStatus::INTERNAL_SERVER_ERROR],
+            );
+        }
+    }
+
+    private function criarTelefone(array $dados, Parceiro $parceiro)
+    {
+        foreach($dados['telefones'] as $telefone) {
+            $telefone['parceiro_id'] = $parceiro->id;
+            $telefone['tipo'] = Telefone::TIPO_TELEFONES[$telefone['tipo']];
+            $novoTelefone = Telefone::create($telefone);
+
+            throw_if(
+                !$novoTelefone,
+                Exception::class,
+                [ApiError::falhaSalvarTelefone(), HttpStatus::INTERNAL_SERVER_ERROR],
+            );
+        }
+    }
+}

--- a/app/Traits/FormRequest.php
+++ b/app/Traits/FormRequest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Traits;
 
+use App\Models\Parceiro;
+use App\Models\Telefone;
 use App\Models\TipoPessoa;
 use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest as FormRequestBase;
@@ -76,5 +78,33 @@ trait FormRequest
             ->find($formRequest->id);
 
         return $usuario->exists ?? false;
+    }
+
+    /**
+     * Valida se o CPF ou CNPJ pertence ao parceiro com o ID especificado.
+     *
+     * @param FormRequestBase $formRequest
+     * @return bool
+     */
+    protected function validateCpfOrCnpjBelongsToId(FormRequestBase $formRequest): bool
+    {
+        $parceiro = Parceiro::find($formRequest->id);
+
+        return !is_null($parceiro) &&
+            (($parceiro->tipoPessoa->cpf_cnpj == $formRequest->cpf) ||
+            ($parceiro->tipoPessoa->cpf_cnpj == $formRequest->cnpj));
+    }
+
+    /**
+     * Valida se o telefone pertence ao parceiro com o ID especificado.
+     *
+     * @param FormRequestBase $formRequest
+     * @return bool
+     */
+    protected function validateTelefoneBelongsToId(FormRequestBase $formRequest): bool
+    {
+        return Telefone::where('parceiro_id', '=', $formRequest->id)
+            ->whereIn('telefone', array_column($formRequest->telefones, 'telefone'))
+            ->exists();
     }
 }

--- a/database/migrations/2020_04_25_190145_create_table_parceiros.php
+++ b/database/migrations/2020_04_25_190145_create_table_parceiros.php
@@ -19,7 +19,7 @@ class CreateTableParceiros extends Migration
             $table->string('email');
             $table->unsignedBigInteger('tipo_pessoa_id');
 
-            $table->foreign('tipo_pessoa_id')->references('id')->on('tipo_pessoas');
+            $table->foreign('tipo_pessoa_id')->references('id')->on('tipos_pessoa');
 
             $table->timestamps();
         });

--- a/postman_environment.json
+++ b/postman_environment.json
@@ -1,0 +1,14 @@
+{
+	"id": "ba5f03ba-45e7-41b4-aea6-18cb48cd8d91",
+	"name": "Manaus Mais Humana",
+	"values": [
+		{
+			"key": "url",
+			"value": "http://back.localhost",
+			"enabled": true
+		}
+	],
+	"_postman_variable_scope": "environment",
+	"_postman_exported_at": "2020-05-03T19:53:41.165Z",
+	"_postman_exported_using": "Postman/7.23.0"
+}

--- a/resources/docs/source/.compare.md
+++ b/resources/docs/source/.compare.md
@@ -691,6 +691,872 @@ Parameter | Type | Status | Description
     
 <!-- END_64744f99fcf3bece9ec84aee8c3b0cfc -->
 
+#ParceiroController
+
+
+Controller responsável pelo CRUD de instituições parceiras.
+<!-- START_0d4dfb28e77c127afb29ac9f5077f22f -->
+## Listar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar uma lista de parceiros.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let params = {
+    "page": ""1"",
+    "limit": ""6"",
+};
+Object.keys(params)
+    .forEach(key => url.searchParams.append(key, params[key]));
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'query' => [
+            'page'=> '"1"',
+            'limit'=> '"6"',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+params = {
+  'page': '"1"',
+  'limit': '"6"',
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers, params=params)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros?page=%221%22&limit=%226%22" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros`
+
+#### Query Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -----------
+    `page` |  optional  | Número da página para retornar os dados.
+    `limit` |  optional  | Total de elementos por página para retornar.
+
+<!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
+
+<!-- START_a072594af821ade9e7ce15d71dbe9460 -->
+## Buscar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para obter os dados de um parceiro específico.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": [
+        {
+            "id": 1,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "message": "Parceiro encontrado!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 1 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+
+<!-- END_a072594af821ade9e7ce15d71dbe9460 -->
+
+<!-- START_543d37f5ea560f7ea10b487b2b15671f -->
+## Criar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para inserir uma nova instituição parceira no sistema.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: body
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->post(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'json' => [
+            'nome' => 'Manaus+Humana',
+            'email' => 'fulano@tal.com',
+            'cnpj' => '13245678901234',
+            'cpf' => '12345678901',
+            'telefones' => [
+                [
+                    'telefone' => 92991234567,
+                    'tipo' => 'itaque',
+                ],
+            ],
+            'enderecos' => [
+                [
+                    'endereco' => 'Rua da paz, 150',
+                    'bairro_id' => 1,
+                    'cep' => '"69061000"',
+                    'ponto_referencia' => '"INPA"',
+                    'cidade_id' => 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('POST', url, headers=headers, json=payload)
+response.json()
+```
+
+```bash
+curl -X POST \
+    "http://localhost/api/v1/parceiros" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"itaque"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+
+```
+
+
+> Example response (201):
+
+```json
+{
+    "data": {
+        "id": 2
+    },
+    "message": "Parceiro criado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (422):
+
+```json
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`POST api/v1/parceiros`
+
+#### Body Parameters
+Parameter | Type | Status | Description
+--------- | ------- | ------- | ------- | -----------
+    `nome` | string |  required  | Nome do novo parceiro - (max. 255).
+        `email` | string |  required  | Endereço de e-mail do parceiro - (max. 255).
+        `cnpj` | string |  optional  | Número do CNPJ da instituição (obrigatório se não houver CPF).
+        `cpf` | string |  optional  | Número do CPF da instituição (obrigatório se não houver CNPJ).
+        `telefones` | array |  required  | Lista de telefones.
+        `telefones[0].telefone` | integer |  required  | Número de telefone com DDD.
+        `telefones[0].tipo` | string |  required  | Tipo do telefone: "Fixo" ou "Celular"
+        `enderecos` | array |  required  | Lista de enderecos.
+        `enderecos[0].endereco` | string |  required  | Nome da rua, com número e complemento.
+        `enderecos[0].bairro_id` | integer |  required  | ID do bairro.
+        `enderecos[0].cep` | string |  required  | CEP da rua.
+        `enderecos[0].ponto_referencia` | string |  optional  | Ponto de referência.
+        `enderecos[0].cidade_id` | integer |  required  | ID da cidade.
+    
+<!-- END_543d37f5ea560f7ea10b487b2b15671f -->
+
+<!-- START_5aaa67f3f0225463d7c25473608a7464 -->
+## Atualizar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para atualizar os dados de um parceiro.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "PUT",
+    headers: headers,
+    body: body
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->put(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'json' => [
+            'nome' => 'Manaus+Humana',
+            'email' => 'fulano@tal.com',
+            'cnpj' => '13245678901234',
+            'cpf' => '12345678901',
+            'telefones' => [
+                [
+                    'telefone' => 92991234567,
+                    'tipo' => 'nisi',
+                ],
+            ],
+            'enderecos' => [
+                [
+                    'endereco' => 'Rua da paz, 150',
+                    'bairro_id' => 1,
+                    'cep' => '"69061000"',
+                    'ponto_referencia' => '"INPA"',
+                    'cidade_id' => 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('PUT', url, headers=headers, json=payload)
+response.json()
+```
+
+```bash
+curl -X PUT \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"nisi"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": {
+        "id": 1,
+        "nome": "Ação de Graças",
+        "email": "contato@gracas.com.br",
+        "tipo_pessoa": {
+            "id": 9,
+            "tipo_pessoa": "pj",
+            "cpf_cnpj": "09627659000147"
+        },
+        "telefones": [
+            {
+                "id": 9,
+                "telefone": "92991475871",
+                "tipo": 1
+            }
+        ],
+        "enderecos": [
+            {
+                "id": 11,
+                "endereco": "Rua da Onça",
+                "ponto_referencia": null,
+                "cep": "69068748",
+                "cidade": {
+                    "nome": "Manaus",
+                    "estado": {
+                        "uf": "AM",
+                        "nome": "Amazonas"
+                    }
+                },
+                "bairro": {
+                    "nome": "Raiz"
+                }
+            }
+        ]
+    },
+    "message": "Parceiro atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}
+```
+> Example response (422):
+
+```json
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`PUT api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+#### Body Parameters
+Parameter | Type | Status | Description
+--------- | ------- | ------- | ------- | -----------
+    `nome` | string |  required  | Nome do novo parceiro - (max. 255).
+        `email` | string |  required  | Endereço de e-mail do parceiro - (max. 255).
+        `cnpj` | string |  optional  | Número do CNPJ da instituição (obrigatório se não houver CPF).
+        `cpf` | string |  optional  | Número do CPF da instituição (obrigatório se não houver CNPJ).
+        `telefones` | array |  required  | Lista de telefones.
+        `telefones[0].telefone` | integer |  required  | Número de telefone com DDD.
+        `telefones[0].tipo` | string |  required  | Tipo do telefone: "Fixo" ou "Celular"
+        `enderecos` | array |  required  | Lista de enderecos
+        `enderecos[0].endereco` | string |  required  | Nome da rua, com número e complemento.
+        `enderecos[0].bairro_id` | integer |  required  | ID do bairro.
+        `enderecos[0].cep` | string |  required  | CEP da rua.
+        `enderecos[0].ponto_referencia` | string |  optional  | Ponto de referência.
+        `enderecos[0].cidade_id` | integer |  required  | ID da cidade.
+    
+<!-- END_5aaa67f3f0225463d7c25473608a7464 -->
+
+<!-- START_ce8ca1fc55cd829a93844b4be19d491a -->
+## Remover
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para remover um parceiro do sistema.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "DELETE",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->delete(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('DELETE', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X DELETE \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": [],
+    "message": "Parceiro removido com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`DELETE api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+
+<!-- END_ce8ca1fc55cd829a93844b4be19d491a -->
+
 #UsuarioController
 
 

--- a/resources/docs/source/index.md
+++ b/resources/docs/source/index.md
@@ -691,6 +691,872 @@ Parameter | Type | Status | Description
     
 <!-- END_64744f99fcf3bece9ec84aee8c3b0cfc -->
 
+#ParceiroController
+
+
+Controller responsável pelo CRUD de instituições parceiras.
+<!-- START_0d4dfb28e77c127afb29ac9f5077f22f -->
+## Listar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar uma lista de parceiros.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let params = {
+    "page": ""1"",
+    "limit": ""6"",
+};
+Object.keys(params)
+    .forEach(key => url.searchParams.append(key, params[key]));
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'query' => [
+            'page'=> '"1"',
+            'limit'=> '"6"',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+params = {
+  'page': '"1"',
+  'limit': '"6"',
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers, params=params)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros?page=%221%22&limit=%226%22" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros`
+
+#### Query Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -----------
+    `page` |  optional  | Número da página para retornar os dados.
+    `limit` |  optional  | Total de elementos por página para retornar.
+
+<!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
+
+<!-- START_a072594af821ade9e7ce15d71dbe9460 -->
+## Buscar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para obter os dados de um parceiro específico.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": [
+        {
+            "id": 1,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "message": "Parceiro encontrado!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 1 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+
+<!-- END_a072594af821ade9e7ce15d71dbe9460 -->
+
+<!-- START_543d37f5ea560f7ea10b487b2b15671f -->
+## Criar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para inserir uma nova instituição parceira no sistema.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: body
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->post(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'json' => [
+            'nome' => 'Manaus+Humana',
+            'email' => 'fulano@tal.com',
+            'cnpj' => '13245678901234',
+            'cpf' => '12345678901',
+            'telefones' => [
+                [
+                    'telefone' => 92991234567,
+                    'tipo' => 'itaque',
+                ],
+            ],
+            'enderecos' => [
+                [
+                    'endereco' => 'Rua da paz, 150',
+                    'bairro_id' => 1,
+                    'cep' => '"69061000"',
+                    'ponto_referencia' => '"INPA"',
+                    'cidade_id' => 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('POST', url, headers=headers, json=payload)
+response.json()
+```
+
+```bash
+curl -X POST \
+    "http://localhost/api/v1/parceiros" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"itaque"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+
+```
+
+
+> Example response (201):
+
+```json
+{
+    "data": {
+        "id": 2
+    },
+    "message": "Parceiro criado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (422):
+
+```json
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`POST api/v1/parceiros`
+
+#### Body Parameters
+Parameter | Type | Status | Description
+--------- | ------- | ------- | ------- | -----------
+    `nome` | string |  required  | Nome do novo parceiro - (max. 255).
+        `email` | string |  required  | Endereço de e-mail do parceiro - (max. 255).
+        `cnpj` | string |  optional  | Número do CNPJ da instituição (obrigatório se não houver CPF).
+        `cpf` | string |  optional  | Número do CPF da instituição (obrigatório se não houver CNPJ).
+        `telefones` | array |  required  | Lista de telefones.
+        `telefones[0].telefone` | integer |  required  | Número de telefone com DDD.
+        `telefones[0].tipo` | string |  required  | Tipo do telefone: "Fixo" ou "Celular"
+        `enderecos` | array |  required  | Lista de enderecos.
+        `enderecos[0].endereco` | string |  required  | Nome da rua, com número e complemento.
+        `enderecos[0].bairro_id` | integer |  required  | ID do bairro.
+        `enderecos[0].cep` | string |  required  | CEP da rua.
+        `enderecos[0].ponto_referencia` | string |  optional  | Ponto de referência.
+        `enderecos[0].cidade_id` | integer |  required  | ID da cidade.
+    
+<!-- END_543d37f5ea560f7ea10b487b2b15671f -->
+
+<!-- START_5aaa67f3f0225463d7c25473608a7464 -->
+## Atualizar
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para atualizar os dados de um parceiro.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "PUT",
+    headers: headers,
+    body: body
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->put(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+        'json' => [
+            'nome' => 'Manaus+Humana',
+            'email' => 'fulano@tal.com',
+            'cnpj' => '13245678901234',
+            'cpf' => '12345678901',
+            'telefones' => [
+                [
+                    'telefone' => 92991234567,
+                    'tipo' => 'nisi',
+                ],
+            ],
+            'enderecos' => [
+                [
+                    'endereco' => 'Rua da paz, 150',
+                    'bairro_id' => 1,
+                    'cep' => '"69061000"',
+                    'ponto_referencia' => '"INPA"',
+                    'cidade_id' => 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('PUT', url, headers=headers, json=payload)
+response.json()
+```
+
+```bash
+curl -X PUT \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"nisi"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": {
+        "id": 1,
+        "nome": "Ação de Graças",
+        "email": "contato@gracas.com.br",
+        "tipo_pessoa": {
+            "id": 9,
+            "tipo_pessoa": "pj",
+            "cpf_cnpj": "09627659000147"
+        },
+        "telefones": [
+            {
+                "id": 9,
+                "telefone": "92991475871",
+                "tipo": 1
+            }
+        ],
+        "enderecos": [
+            {
+                "id": 11,
+                "endereco": "Rua da Onça",
+                "ponto_referencia": null,
+                "cep": "69068748",
+                "cidade": {
+                    "nome": "Manaus",
+                    "estado": {
+                        "uf": "AM",
+                        "nome": "Amazonas"
+                    }
+                },
+                "bairro": {
+                    "nome": "Raiz"
+                }
+            }
+        ]
+    },
+    "message": "Parceiro atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}
+```
+> Example response (422):
+
+```json
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`PUT api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+#### Body Parameters
+Parameter | Type | Status | Description
+--------- | ------- | ------- | ------- | -----------
+    `nome` | string |  required  | Nome do novo parceiro - (max. 255).
+        `email` | string |  required  | Endereço de e-mail do parceiro - (max. 255).
+        `cnpj` | string |  optional  | Número do CNPJ da instituição (obrigatório se não houver CPF).
+        `cpf` | string |  optional  | Número do CPF da instituição (obrigatório se não houver CNPJ).
+        `telefones` | array |  required  | Lista de telefones.
+        `telefones[0].telefone` | integer |  required  | Número de telefone com DDD.
+        `telefones[0].tipo` | string |  required  | Tipo do telefone: "Fixo" ou "Celular"
+        `enderecos` | array |  required  | Lista de enderecos
+        `enderecos[0].endereco` | string |  required  | Nome da rua, com número e complemento.
+        `enderecos[0].bairro_id` | integer |  required  | ID do bairro.
+        `enderecos[0].cep` | string |  required  | CEP da rua.
+        `enderecos[0].ponto_referencia` | string |  optional  | Ponto de referência.
+        `enderecos[0].cidade_id` | integer |  required  | ID da cidade.
+    
+<!-- END_5aaa67f3f0225463d7c25473608a7464 -->
+
+<!-- START_ce8ca1fc55cd829a93844b4be19d491a -->
+## Remover
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para remover um parceiro do sistema.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "DELETE",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->delete(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('DELETE', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X DELETE \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": [],
+    "message": "Parceiro removido com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+> Example response (404):
+
+```json
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`DELETE api/v1/parceiros/{id}`
+
+#### URL Parameters
+
+Parameter | Status | Description
+--------- | ------- | ------- | -------
+    `parceiro` |  required  | ID do parceiro.
+
+<!-- END_ce8ca1fc55cd829a93844b4be19d491a -->
+
 #UsuarioController
 
 

--- a/resources/views/apidoc/index.blade.php
+++ b/resources/views/apidoc/index.blade.php
@@ -733,6 +733,963 @@ response.json()</code></pre>
 </tbody>
 </table>
 <!-- END_64744f99fcf3bece9ec84aee8c3b0cfc -->
+<h1>ParceiroController</h1>
+<p>Controller responsável pelo CRUD de instituições parceiras.</p>
+<!-- START_0d4dfb28e77c127afb29ac9f5077f22f -->
+<h2>Listar</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar uma lista de parceiros.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let params = {
+    "page": ""1"",
+    "limit": ""6"",
+};
+Object.keys(params)
+    .forEach(key =&gt; url.searchParams.append(key, params[key]));
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;get(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+        'query' =&gt; [
+            'page'=&gt; '"1"',
+            'limit'=&gt; '"6"',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+params = {
+  'page': '"1"',
+  'limit': '"6"',
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers, params=params)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X GET \
+    -G "http://localhost/api/v1/parceiros?page=%221%22&amp;limit=%226%22" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>GET api/v1/parceiros</code></p>
+<h4>Query Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>page</code></td>
+<td>optional</td>
+<td>Número da página para retornar os dados.</td>
+</tr>
+<tr>
+<td><code>limit</code></td>
+<td>optional</td>
+<td>Total de elementos por página para retornar.</td>
+</tr>
+</tbody>
+</table>
+<!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
+<!-- START_a072594af821ade9e7ce15d71dbe9460 -->
+<h2>Buscar</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para obter os dados de um parceiro específico.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;get(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X GET \
+    -G "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [
+        {
+            "id": 1,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "message": "Parceiro encontrado!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}</code></pre>
+<blockquote>
+<p>Example response (401):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}</code></pre>
+<blockquote>
+<p>Example response (404):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #105: Parceiro 1 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>GET api/v1/parceiros/{id}</code></p>
+<h4>URL Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>parceiro</code></td>
+<td>required</td>
+<td>ID do parceiro.</td>
+</tr>
+</tbody>
+</table>
+<!-- END_a072594af821ade9e7ce15d71dbe9460 -->
+<!-- START_543d37f5ea560f7ea10b487b2b15671f -->
+<h2>Criar</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para inserir uma nova instituição parceira no sistema.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "POST",
+    headers: headers,
+    body: body
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;post(
+    'http://localhost/api/v1/parceiros',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+        'json' =&gt; [
+            'nome' =&gt; 'Manaus+Humana',
+            'email' =&gt; 'fulano@tal.com',
+            'cnpj' =&gt; '13245678901234',
+            'cpf' =&gt; '12345678901',
+            'telefones' =&gt; [
+                [
+                    'telefone' =&gt; 92991234567,
+                    'tipo' =&gt; 'itaque',
+                ],
+            ],
+            'enderecos' =&gt; [
+                [
+                    'endereco' =&gt; 'Rua da paz, 150',
+                    'bairro_id' =&gt; 1,
+                    'cep' =&gt; '"69061000"',
+                    'ponto_referencia' =&gt; '"INPA"',
+                    'cidade_id' =&gt; 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "itaque"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('POST', url, headers=headers, json=payload)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X POST \
+    "http://localhost/api/v1/parceiros" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"itaque"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+</code></pre>
+<blockquote>
+<p>Example response (201):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": {
+        "id": 2
+    },
+    "message": "Parceiro criado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<blockquote>
+<p>Example response (401):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}</code></pre>
+<blockquote>
+<p>Example response (422):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>POST api/v1/parceiros</code></p>
+<h4>Body Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>nome</code></td>
+<td>string</td>
+<td>required</td>
+<td>Nome do novo parceiro - (max. 255).</td>
+</tr>
+<tr>
+<td><code>email</code></td>
+<td>string</td>
+<td>required</td>
+<td>Endereço de e-mail do parceiro - (max. 255).</td>
+</tr>
+<tr>
+<td><code>cnpj</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Número do CNPJ da instituição (obrigatório se não houver CPF).</td>
+</tr>
+<tr>
+<td><code>cpf</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Número do CPF da instituição (obrigatório se não houver CNPJ).</td>
+</tr>
+<tr>
+<td><code>telefones</code></td>
+<td>array</td>
+<td>required</td>
+<td>Lista de telefones.</td>
+</tr>
+<tr>
+<td><code>telefones[0].telefone</code></td>
+<td>integer</td>
+<td>required</td>
+<td>Número de telefone com DDD.</td>
+</tr>
+<tr>
+<td><code>telefones[0].tipo</code></td>
+<td>string</td>
+<td>required</td>
+<td>Tipo do telefone: &quot;Fixo&quot; ou &quot;Celular&quot;</td>
+</tr>
+<tr>
+<td><code>enderecos</code></td>
+<td>array</td>
+<td>required</td>
+<td>Lista de enderecos.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].endereco</code></td>
+<td>string</td>
+<td>required</td>
+<td>Nome da rua, com número e complemento.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].bairro_id</code></td>
+<td>integer</td>
+<td>required</td>
+<td>ID do bairro.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].cep</code></td>
+<td>string</td>
+<td>required</td>
+<td>CEP da rua.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].ponto_referencia</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Ponto de referência.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].cidade_id</code></td>
+<td>integer</td>
+<td>required</td>
+<td>ID da cidade.</td>
+</tr>
+</tbody>
+</table>
+<!-- END_543d37f5ea560f7ea10b487b2b15671f -->
+<!-- START_5aaa67f3f0225463d7c25473608a7464 -->
+<h2>Atualizar</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para atualizar os dados de um parceiro.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+let body = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+
+fetch(url, {
+    method: "PUT",
+    headers: headers,
+    body: body
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;put(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+        'json' =&gt; [
+            'nome' =&gt; 'Manaus+Humana',
+            'email' =&gt; 'fulano@tal.com',
+            'cnpj' =&gt; '13245678901234',
+            'cpf' =&gt; '12345678901',
+            'telefones' =&gt; [
+                [
+                    'telefone' =&gt; 92991234567,
+                    'tipo' =&gt; 'nisi',
+                ],
+            ],
+            'enderecos' =&gt; [
+                [
+                    'endereco' =&gt; 'Rua da paz, 150',
+                    'bairro_id' =&gt; 1,
+                    'cep' =&gt; '"69061000"',
+                    'ponto_referencia' =&gt; '"INPA"',
+                    'cidade_id' =&gt; 1,
+                ],
+            ],
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+payload = {
+    "nome": "Manaus+Humana",
+    "email": "fulano@tal.com",
+    "cnpj": "13245678901234",
+    "cpf": "12345678901",
+    "telefones": [
+        {
+            "telefone": 92991234567,
+            "tipo": "nisi"
+        }
+    ],
+    "enderecos": [
+        {
+            "endereco": "Rua da paz, 150",
+            "bairro_id": 1,
+            "cep": "\"69061000\"",
+            "ponto_referencia": "\"INPA\"",
+            "cidade_id": 1
+        }
+    ]
+}
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('PUT', url, headers=headers, json=payload)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X PUT \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json" \
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"nisi"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": {
+        "id": 1,
+        "nome": "Ação de Graças",
+        "email": "contato@gracas.com.br",
+        "tipo_pessoa": {
+            "id": 9,
+            "tipo_pessoa": "pj",
+            "cpf_cnpj": "09627659000147"
+        },
+        "telefones": [
+            {
+                "id": 9,
+                "telefone": "92991475871",
+                "tipo": 1
+            }
+        ],
+        "enderecos": [
+            {
+                "id": 11,
+                "endereco": "Rua da Onça",
+                "ponto_referencia": null,
+                "cep": "69068748",
+                "cidade": {
+                    "nome": "Manaus",
+                    "estado": {
+                        "uf": "AM",
+                        "nome": "Amazonas"
+                    }
+                },
+                "bairro": {
+                    "nome": "Raiz"
+                }
+            }
+        ]
+    },
+    "message": "Parceiro atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}</code></pre>
+<blockquote>
+<p>Example response (401):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}</code></pre>
+<blockquote>
+<p>Example response (404):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}</code></pre>
+<blockquote>
+<p>Example response (422):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>PUT api/v1/parceiros/{id}</code></p>
+<h4>URL Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>parceiro</code></td>
+<td>required</td>
+<td>ID do parceiro.</td>
+</tr>
+</tbody>
+</table>
+<h4>Body Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Type</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>nome</code></td>
+<td>string</td>
+<td>required</td>
+<td>Nome do novo parceiro - (max. 255).</td>
+</tr>
+<tr>
+<td><code>email</code></td>
+<td>string</td>
+<td>required</td>
+<td>Endereço de e-mail do parceiro - (max. 255).</td>
+</tr>
+<tr>
+<td><code>cnpj</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Número do CNPJ da instituição (obrigatório se não houver CPF).</td>
+</tr>
+<tr>
+<td><code>cpf</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Número do CPF da instituição (obrigatório se não houver CNPJ).</td>
+</tr>
+<tr>
+<td><code>telefones</code></td>
+<td>array</td>
+<td>required</td>
+<td>Lista de telefones.</td>
+</tr>
+<tr>
+<td><code>telefones[0].telefone</code></td>
+<td>integer</td>
+<td>required</td>
+<td>Número de telefone com DDD.</td>
+</tr>
+<tr>
+<td><code>telefones[0].tipo</code></td>
+<td>string</td>
+<td>required</td>
+<td>Tipo do telefone: &quot;Fixo&quot; ou &quot;Celular&quot;</td>
+</tr>
+<tr>
+<td><code>enderecos</code></td>
+<td>array</td>
+<td>required</td>
+<td>Lista de enderecos</td>
+</tr>
+<tr>
+<td><code>enderecos[0].endereco</code></td>
+<td>string</td>
+<td>required</td>
+<td>Nome da rua, com número e complemento.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].bairro_id</code></td>
+<td>integer</td>
+<td>required</td>
+<td>ID do bairro.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].cep</code></td>
+<td>string</td>
+<td>required</td>
+<td>CEP da rua.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].ponto_referencia</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Ponto de referência.</td>
+</tr>
+<tr>
+<td><code>enderecos[0].cidade_id</code></td>
+<td>integer</td>
+<td>required</td>
+<td>ID da cidade.</td>
+</tr>
+</tbody>
+</table>
+<!-- END_5aaa67f3f0225463d7c25473608a7464 -->
+<!-- START_ce8ca1fc55cd829a93844b4be19d491a -->
+<h2>Remover</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para remover um parceiro do sistema.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros/1"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "DELETE",
+    headers: headers,
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;delete(
+    'http://localhost/api/v1/parceiros/1',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/1'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('DELETE', url, headers=headers)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X DELETE \
+    "http://localhost/api/v1/parceiros/1" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Parceiro removido com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}</code></pre>
+<blockquote>
+<p>Example response (401):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}</code></pre>
+<blockquote>
+<p>Example response (404):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>DELETE api/v1/parceiros/{id}</code></p>
+<h4>URL Parameters</h4>
+<table>
+<thead>
+<tr>
+<th>Parameter</th>
+<th>Status</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>parceiro</code></td>
+<td>required</td>
+<td>ID do parceiro.</td>
+</tr>
+</tbody>
+</table>
+<!-- END_ce8ca1fc55cd829a93844b4be19d491a -->
 <h1>UsuarioController</h1>
 <p>Controller responsável pelo gerenciamento de Usuários do lado privado.</p>
 <!-- START_94b9e39c9179e6826963c4293a458c30 -->

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,5 +24,6 @@ Route::prefix('v1')->group(function () {
     Route::prefix('parceiros')->group(function () {
         Route::get('/', 'ParceiroController@get')->name('parceiros.get');
         Route::get('/{id}', 'ParceiroController@find')->name('parceiros.getbyid');
+        Route::post('/', 'ParceiroController@store')->name('parceiros.save');
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,4 +21,8 @@ Route::prefix('v1')->group(function () {
         Route::put('{id}/set-password', 'UsuarioController@setPassword')->name('usuario.setPassword');
     });
 
+    Route::prefix('parceiros')->group(function () {
+        Route::get('/', 'ParceiroController@get')->name('parceiros.get');
+        Route::get('/{id}', 'ParceiroController@find')->name('parceiros.getbyid');
+    });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,5 +26,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/{id}', 'ParceiroController@find')->name('parceiros.getbyid');
         Route::post('/', 'ParceiroController@store')->name('parceiros.save');
         Route::put('/{id}', 'ParceiroController@update')->name('parceiros.update');
+        Route::delete('/{id}', 'ParceiroController@delete')->name('parceiros.delete');
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,5 +25,6 @@ Route::prefix('v1')->group(function () {
         Route::get('/', 'ParceiroController@get')->name('parceiros.get');
         Route::get('/{id}', 'ParceiroController@find')->name('parceiros.getbyid');
         Route::post('/', 'ParceiroController@store')->name('parceiros.save');
+        Route::put('/{id}', 'ParceiroController@update')->name('parceiros.update');
     });
 });

--- a/routes_postman.json
+++ b/routes_postman.json
@@ -1,0 +1,155 @@
+{
+	"info": {
+		"_postman_id": "689519b0-6915-480c-a7a9-7f3acd55cf08",
+		"name": "ManausMaisHumana",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Parceiros",
+			"item": [
+				{
+					"name": "Parceiros",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v1/parceiros",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"parceiros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Parceiros ID",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/parceiros/1",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"parceiros",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Parceiros",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"nome\": \"Boa Ação\",\n\t\"email\": \"contato@boacao.com.br\",\n\t\"cnpj\": \"14253678901597\",\n\t\"telefones\": [\n\t\t{\n\t\t\t\"telefone\": \"9236445874\",\n\t\t\t\"tipo\": \"Fixo\"\n\t\t}\n\t],\n\t\"enderecos\": [\n\t\t{\n\t\t\t\"endereco\": \"Rua Açaí\",\n\t\t\t\"bairro_id\": 50,\n\t\t\t\"cep\": \"69068447\",\n\t\t\t\"cidade_id\": 1\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/parceiros",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"parceiros"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Parceiros",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"nome\": \"Ação de Graças\",\n\t\"email\": \"contato@gracas.com.br\",\n\t\"cnpj\": \"45678912602487\",\n\t\"telefones\": [\n\t\t{\n\t\t\t\"telefone\": \"92991475870\",\n\t\t\t\"tipo\": \"Celular\"\n\t\t}\n\t],\n\t\"enderecos\": [\n\t\t{\n\t\t\t\"endereco\": \"Rua Japura\",\n\t\t\t\"bairro_id\": 50,\n\t\t\t\"cep\": \"69068747\",\n\t\t\t\"cidade_id\": 1\n\t\t}\n\t]\n}"
+						},
+						"url": {
+							"raw": "{{url}}/api/v1/parceiros/1",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"parceiros",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Parceiros",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/api/v1/parceiros/1",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"parceiros",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/storage/responses/ParceiroController/delete.200.json
+++ b/storage/responses/ParceiroController/delete.200.json
@@ -1,0 +1,6 @@
+{
+    "data": [],
+    "message": "Parceiro removido com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}

--- a/storage/responses/ParceiroController/delete.404.json
+++ b/storage/responses/ParceiroController/delete.404.json
@@ -1,0 +1,6 @@
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}

--- a/storage/responses/ParceiroController/get.200.json
+++ b/storage/responses/ParceiroController/get.200.json
@@ -1,0 +1,52 @@
+{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                     "id": 1,
+                     "telefone": "9236445874",
+                     "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                         }
+                     },
+                     "bairro": {
+                         "nome": "Raiz"
+                     }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}

--- a/storage/responses/ParceiroController/internalServerError.500.json
+++ b/storage/responses/ParceiroController/internalServerError.500.json
@@ -1,0 +1,6 @@
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}

--- a/storage/responses/ParceiroController/show.200.json
+++ b/storage/responses/ParceiroController/show.200.json
@@ -1,0 +1,42 @@
+{
+    "data": [
+        {
+            "id": 1,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                     "id": 1,
+                     "telefone": "9236445874",
+                     "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                         }
+                     },
+                     "bairro": {
+                         "nome": "Raiz"
+                     }
+                }
+            ]
+        }
+    ],
+    "message": "Parceiro encontrado!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}

--- a/storage/responses/ParceiroController/show.404.json
+++ b/storage/responses/ParceiroController/show.404.json
@@ -1,0 +1,6 @@
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 1 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}

--- a/storage/responses/ParceiroController/store.201.json
+++ b/storage/responses/ParceiroController/store.201.json
@@ -1,0 +1,8 @@
+{
+    "data": {
+        "id": 2
+    },
+    "message": "Parceiro criado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}

--- a/storage/responses/ParceiroController/store.422.json
+++ b/storage/responses/ParceiroController/store.422.json
@@ -1,0 +1,9 @@
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}

--- a/storage/responses/ParceiroController/update.200.json
+++ b/storage/responses/ParceiroController/update.200.json
@@ -1,0 +1,40 @@
+{
+    "data": {
+        "id": 1,
+        "nome": "Ação de Graças",
+        "email": "contato@gracas.com.br",
+        "tipo_pessoa": {
+            "id": 9,
+            "tipo_pessoa": "pj",
+            "cpf_cnpj": "09627659000147"
+        },
+        "telefones": [
+            {
+                "id": 9,
+                "telefone": "92991475871",
+                "tipo": 1
+            }
+        ],
+        "enderecos": [
+            {
+                "id": 11,
+                "endereco": "Rua da Onça",
+                "ponto_referencia": null,
+                "cep": "69068748",
+                "cidade": {
+                    "nome": "Manaus",
+                    "estado": {
+                        "uf": "AM",
+                        "nome": "Amazonas"
+                    }
+                },
+                "bairro": {
+                    "nome": "Raiz"
+                }
+            }
+        ]
+    },
+    "message": "Parceiro atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}

--- a/storage/responses/ParceiroController/update.404.json
+++ b/storage/responses/ParceiroController/update.404.json
@@ -1,0 +1,6 @@
+{
+    "data": [],
+    "message": "Erro #105: Parceiro 2 não encontrado.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/2"
+}

--- a/storage/responses/ParceiroController/update.422.json
+++ b/storage/responses/ParceiroController/update.422.json
@@ -1,0 +1,9 @@
+{
+    "data": [],
+    "errors": [
+        "O Nome é obrigatório."
+    ],
+    "message": "Existem campos inválidos.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros\/1"
+}


### PR DESCRIPTION
## Descrição

Criar as rotas de inserção, listagem, atualização e remoção de instituições parceiras. As seguintes rotas foram criadas:

**GET /api/v1/parceiros**: rota que lista todas as instituições parceiras cadastradas.
**GET /api/v1/parceiros/{id}**: rota que os dados de uma instituição parceira específica.
**POST /api/v1/parceiros**: rota de inserção de uma instituição parceira.
**PUT /api/v1/parceiros/{id}**: rota de atualização dos dados de uma instituição parceira específica.
**DELETE /api/v1/parceiros/{id}**: rota de remoção de uma instituição parceira específica.

Abaixo segue um exemplo do body das requisições POST e PUT:
```
{
	"nome": "Boa Ação",
	"email": "contato@boacao.com.br",
	"cnpj": "14253678901597",
	"telefones": [
		{
			"telefone": "9236445874",
			"tipo": "Fixo"
		}
	],
	"enderecos": [
		{
			"endereco": "Rua Açaí",
			"bairro_id": 50,
			"cep": "69068447",
			"cidade_id": 1
		}
	]
}
```

## Cenário de teste

- Para facilitar o teste dessas rotas, usar a ferramenta o Postman. Na raiz do projeto, há dois arquivos, `routes_postman.json` e `postman_environment.json`. Importe os dois arquivos no Postman para ter acesso as rotas criadas.
- Para testar esta PR, é preciso atualizar o banco de dados com as migrações [desta PR](https://github.com/MANAUS-MAIS-HUMANA/mmh-service/pull/10).

Testar os seguintes cenários neste PR:
- Chamar a rota `GET /parceiros` para buscar parceiros existentes, sendo que ainda não existe parceiros cadastrados. Nesse caso, a rota deve retornar 200, mas um array vazio.
- Chamar a rota `GET /parceiros/{id}` para buscar um parceiro não cadastrado no banco. Nesse caso, a rota deve retornar 404.
- Chamar a rota `POST /parceiros` para cadastrar um parceiro, mas passando campos incorretos (por exemplo, em vez de `nome`, colocar `name`). Nesse caso, a rota deve retornar 422.
- Chamar a rota `POST /parceiros` para cadastrar um parceiro, mas não passando CPF ou CNPJ. Nesse caso, a rota deve retornar 400.
- Chamar a rota `POST /parceiros` e inserir os dados válidos. Nesse caso, a rota deve retornar 201 e os elementos devem ser inseridos na tabela `parceiros`, `tipo_pessoas`, `enderecos` e `telefones`.
- Chamar a rota `PUT /parceiros/{id}` e inserir o ID de um parceiro não existe. Nesse caso, a rota deve retornar 404.
- Chamar a rota `PUT /parceiros/{id}`, inserindo o ID um parceiro existente, além de um ou mais dados incorretos. Nesse caso, a rota deve retornar 422.
- Chamar a rota `PUT /parceiros/{id}`, inserindo o ID um parceiro existente, além de todos os dados corretos. Nesse caso, a rota deve retornar 200 e as tabelas serem atualizadas com os novos dados.
- Chamar a rota `DELETE /parceiros/{id}` e inserir o ID de um parceiro não existe. Nesse caso, a rota deve retornar 404.
- Chamar a rota `DELETE /parceiros/{id}` e inserir o ID de um parceiro existente. Nesse caso, a rota deve retornar 200 e todos os dados desse parceiro devem ser removidos das tabelas `parceiros`, `tipo_pessoas`, `enderecos` e `telefones`.