### PR TITLE
Corrigir bug em validação de dados dos usuários

### DIFF
--- a/app/Http/Requests/Auth/CriarUsuarioRequest.php
+++ b/app/Http/Requests/Auth/CriarUsuarioRequest.php
@@ -107,12 +107,14 @@ class CriarUsuarioRequest extends FormRequest
      */
     protected function failedValidation(Validator $validator): void
     {
-        throw new HttpResponseException(
-            (new FailedResource(null, false, "Existem campos inválidos.", $this->replaceErroTipoPessoa
-            ($validator)))
-                ->response()
-                ->setStatusCode(422)
+        $failedResource = new FailedResource(
+            null,
+            false,
+            "Existem campos inválidos.",
+            $validator->errors()->unique(),
         );
+
+        throw new HttpResponseException($failedResource->response()->setStatusCode(422));
     }
 
     /**


### PR DESCRIPTION
## Descrição

Remover chamada a método que não existe. Ele era chamado quando ocorria um erro de validação.

## Cenário de teste

Para testar esta PR, seguir os passos abaixo:

Limpar o banco de dados, executando os comandos abaixo:
```
cd <raiz do mmh-traefik>
make shell
./artisan migrate:refresh
./artisan db:seed
```

Em seguida, chamar a rota de criar novo usuário para o endpoint `POST http://back.localhost/api/v1/auth/create`, com os dados a seguir:

Header:
```
Content-Type: application/json
Accept: application/json
```

Body:
```
{
    "nome": "Seu Nome",
    "email": "seu.email@gmail.com",
    "senha": "algumasenha",
    "senha_confirmation": "algumasenha",
    "endereco": "Alguma rua",
    "estado": "AM",
    "tipo_pessoa": "pj",
    "cnpj": "96.149.102/0001-42"
}
```

**Resultado esperado**: o usuário deve ser criado sem erros.

Testar também a rota passando algum parâmetro incorreto. Espera-se que a validação ocorra sem problemas e no retorno da rota seja apontado o campo incorreto.