### PR TITLE
Adicionar rota de refresh token

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\Auth\CriarUsuarioResource;
 use App\Http\Resources\Auth\LoginResource;
 use App\Http\Resources\Auth\LogoutResource;
 use App\Http\Resources\Auth\RedefinirSenhaResource;
+use App\Http\Resources\Auth\RefreshResource;
 use App\Services\AuthService;
 use Illuminate\Http\JsonResponse;
 
@@ -191,5 +192,32 @@ class AuthController extends Controller
         ))
             ->response()
             ->setStatusCode($result['code']);
+    }
+
+    /**
+     * Refresh Access token
+     *
+     * Endpoint para fazer um refresh de um access token previamente gerado.
+     * Após o refresh, o token antigo não poderá ser mais usado.
+     *
+     * @authenticated
+     *
+     * @responseFile 200 responses/AuthController/refresh.200.json
+     * @responseFile 401 responses/Middleware/unauthorized.401.json
+     *
+     * @param ConfirmarRedefinirSenhaRequest $request
+     * @return JsonResponse
+     */
+    public function refresh(): JsonResponse
+    {
+        $result = $this->authService->refresh();
+
+        $resource = new RefreshResource(
+            $result['data'] ??= null,
+            $result['success'],
+            $result['message'],
+        );
+
+        return $resource->response()->setStatusCode($result['code']);
     }
 }

--- a/app/Http/Resources/Auth/RefreshResource.php
+++ b/app/Http/Resources/Auth/RefreshResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources\Auth;
+
+use App\Http\Resources\ResourceBase;
+
+class RefreshResource extends ResourceBase
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return $this->resource;
+    }
+}

--- a/app/Http/Resources/ResourceBase.php
+++ b/app/Http/Resources/ResourceBase.php
@@ -43,7 +43,6 @@ class ResourceBase extends JsonResource
         ];
 
         $this->setErrors($response);
-        $this->setRefreshToken($response);
 
         return Arr::sortRecursive($response);
     }
@@ -57,18 +56,6 @@ class ResourceBase extends JsonResource
     {
         if (!empty($this->errors)) {
             $response['errors'] = $this->errors;
-        }
-    }
-
-    /**
-     * Inclui o refreshToken ao response
-     *
-     * @param array $response
-     */
-    private function setRefreshToken(array &$response): void
-    {
-        if (!Str::contains(url()->full(), ['auth', 'set-password']) && auth()->check()) {
-            $response['refreshToken'] = auth()->refresh();
         }
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -218,6 +218,31 @@ class AuthService
     }
 
     /**
+     * Faz o refresh do token gerado durante o login
+     *
+     * @return array
+     */
+    public function refresh(): array
+    {
+        try {
+            $token = auth('api')->refresh();
+
+            return [
+                'success' => true,
+                'data' => $this->respondWithToken((string)$token),
+                'message' => 'Token atualizado com sucesso!',
+                'code' => 200,
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+                'code' => 500,
+            ];
+        }
+    }
+
+    /**
      * Retorna os dados de acesso
      *
      * @param string $token

--- a/resources/docs/source/.compare.md
+++ b/resources/docs/source/.compare.md
@@ -407,6 +407,100 @@ Parameter | Type | Status | Description
     
 <!-- END_a4a233f86d97c8deebe3bedaa936f967 -->
 
+<!-- START_4b77551ffe3e806c992cdd1044012aa7 -->
+## Refresh Access token
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para fazer um refresh de um access token previamente gerado.
+Após o refresh, o token antigo não poderá ser mais usado.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/auth/refresh"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/auth/refresh',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/auth/refresh'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/auth/refresh" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": {
+        "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9iYWNrLmxvY2FsaG9",
+        "token_type": "Bearer",
+        "expires_in": 3600
+    },
+    "message": "Token atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/auth\/refresh"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+
+### HTTP Request
+`GET api/v1/auth/refresh`
+
+
+<!-- END_4b77551ffe3e806c992cdd1044012aa7 -->
+
 <!-- START_758d1bc327f18e2d4dbb9b0a22083976 -->
 ## Password Reset
 
@@ -1028,7 +1122,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "earum"
+            "tipo": "voluptas"
         }
     ],
     "enderecos": [
@@ -1069,7 +1163,7 @@ $response = $client->post(
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'earum',
+                    'tipo' => 'voluptas',
                 ],
             ],
             'enderecos' => [
@@ -1101,7 +1195,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "earum"
+            "tipo": "voluptas"
         }
     ],
     "enderecos": [
@@ -1127,7 +1221,7 @@ curl -X POST \
     "http://localhost/api/v1/parceiros" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"earum"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"voluptas"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -1225,7 +1319,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "numquam"
+            "tipo": "accusantium"
         }
     ],
     "enderecos": [
@@ -1266,7 +1360,7 @@ $response = $client->put(
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'numquam',
+                    'tipo' => 'accusantium',
                 ],
             ],
             'enderecos' => [
@@ -1298,7 +1392,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "numquam"
+            "tipo": "accusantium"
         }
     ],
     "enderecos": [
@@ -1324,7 +1418,7 @@ curl -X PUT \
     "http://localhost/api/v1/parceiros/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"numquam"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"accusantium"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 

--- a/resources/docs/source/index.md
+++ b/resources/docs/source/index.md
@@ -152,6 +152,7 @@ Parameter | Type | Status | Description
         `senha` | string |  required  | Senha (min. 8).
     
 <!-- END_2be1f0e022faf424f18f30275e61416e -->
+
 <!-- START_a68ff660ea3d08198e527df659b17963 -->
 ## Logout
 
@@ -405,6 +406,101 @@ Parameter | Type | Status | Description
         `senha_confirmation` | string |  required  | Confirmação de senha de usuário.
     
 <!-- END_a4a233f86d97c8deebe3bedaa936f967 -->
+
+<!-- START_4b77551ffe3e806c992cdd1044012aa7 -->
+## Refresh Access token
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para fazer um refresh de um access token previamente gerado.
+Após o refresh, o token antigo não poderá ser mais usado.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/auth/refresh"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/auth/refresh',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/auth/refresh'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/auth/refresh" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "data": {
+        "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9iYWNrLmxvY2FsaG9",
+        "token_type": "Bearer",
+        "expires_in": 3600
+    },
+    "message": "Token atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/auth\/refresh"
+}
+```
+> Example response (401):
+
+```json
+{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}
+```
+
+### HTTP Request
+`GET api/v1/auth/refresh`
+
+
+<!-- END_4b77551ffe3e806c992cdd1044012aa7 -->
+
 <!-- START_758d1bc327f18e2d4dbb9b0a22083976 -->
 ## Password Reset
 
@@ -546,6 +642,7 @@ Parameter | Type | Status | Description
     `email` | string |  required  | Endereço de e-mail.
     
 <!-- END_758d1bc327f18e2d4dbb9b0a22083976 -->
+
 <!-- START_64744f99fcf3bece9ec84aee8c3b0cfc -->
 ## Confirm Password Reset
 
@@ -687,6 +784,7 @@ Parameter | Type | Status | Description
         `senha_confirmation` | string |  required  | Confirmação de nova senha.
     
 <!-- END_64744f99fcf3bece9ec84aee8c3b0cfc -->
+
 #ParceiroController
 
 
@@ -1904,6 +2002,7 @@ Parameter | Type | Status | Description
         `perfis[0].descricao` | string |  optional  | Descrição do perfil.
     
 <!-- END_f4118dbd959bf0da643fc902f2d8ba1b -->
+
 <!-- START_33b204ea4b1df799847e39ea5600738b -->
 ## Show
 
@@ -2230,6 +2329,7 @@ Parameter | Type | Status | Description
         `status` | string |  optional  | Status de usuário (A, I ou B).
     
 <!-- END_6a759fafba79060dfb4b8762a07e4c23 -->
+
 <!-- START_c72d2f99606a3aefdfc00ac95b31d8d1 -->
 ## SetStatus
 
@@ -2378,6 +2478,7 @@ Parameter | Type | Status | Description
     `status` | string |  optional  | Status de usuário (A, I ou B).
     
 <!-- END_c72d2f99606a3aefdfc00ac95b31d8d1 -->
+
 <!-- START_af574b0c80b0d9c34cb32ac5d2367e41 -->
 ## SetPassword
 
@@ -2540,4 +2641,5 @@ Parameter | Type | Status | Description
         `senha_confirmation` | string |  required  | Confirmação de nova senha.
     
 <!-- END_af574b0c80b0d9c34cb32ac5d2367e41 -->
+
 

--- a/resources/views/apidoc/index.blade.php
+++ b/resources/views/apidoc/index.blade.php
@@ -446,6 +446,80 @@ response.json()</code></pre>
 </tbody>
 </table>
 <!-- END_a4a233f86d97c8deebe3bedaa936f967 -->
+<!-- START_4b77551ffe3e806c992cdd1044012aa7 -->
+<h2>Refresh Access token</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para fazer um refresh de um access token previamente gerado.
+Após o refresh, o token antigo não poderá ser mais usado.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/auth/refresh"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;get(
+    'http://localhost/api/v1/auth/refresh',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/auth/refresh'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X GET \
+    -G "http://localhost/api/v1/auth/refresh" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": {
+        "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9iYWNrLmxvY2FsaG9",
+        "token_type": "Bearer",
+        "expires_in": 3600
+    },
+    "message": "Token atualizado com sucesso!",
+    "success": true,
+    "url": "http:\/\/back.localhost\/api\/v1\/auth\/refresh"
+}</code></pre>
+<blockquote>
+<p>Example response (401):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Não autorizado",
+    "success": false
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>GET api/v1/auth/refresh</code></p>
+<!-- END_4b77551ffe3e806c992cdd1044012aa7 -->
 <!-- START_758d1bc327f18e2d4dbb9b0a22083976 -->
 <h2>Password Reset</h2>
 <p>Endpoint para solicitação de redefinição de senha do usuário.</p>

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ Route::prefix('v1')->group(function () {
         Route::post('login', 'AuthController@login')->name('auth.login');
         Route::post('logout', 'AuthController@logout')->name('auth.logout');
         Route::post('create', 'AuthController@create')->name('auth.create');
+        Route::get('refresh', 'AuthController@refresh')->name('auth.refresh');
         Route::post('password-reset', 'AuthController@passwordReset')->name('auth.passwordReset');
         Route::post('confirm-password-reset', 'AuthController@confirmPasswordReset')->name('auth.confirmPasswordReset');
     });

--- a/storage/responses/AuthController/refresh.200.json
+++ b/storage/responses/AuthController/refresh.200.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9iYWNrLmxvY2FsaG9",
+    "token_type": "Bearer",
+    "expires_in": 3600
+  },
+  "message": "Token atualizado com sucesso!",
+  "success": true,
+  "url": "http:\/\/back.localhost\/api\/v1\/auth\/refresh"
+}


### PR DESCRIPTION
## Descrição

Adicionar a rota GET "/api/v1/auth/refresh", que possibilita ao client atualizar o token antes que ele expire. Além disso, foi removido a atualização do access token em cada requisição. Com isso, agora será possível fazer chamadas simultâneas usando o mesmo token. Antes isso não era possível, forçando aos clientes a fazer chamadas sequênciais ao backend, o que poderia causar um problema de desempenho.

## Setup

- Antes de testar, certifique-se de que o seu banco de dados está atualizado. Para isso, execute o comando `make db-migrate-refresh-seed`, que irá executar todas as migrações e seeds.
- Para obter um token, você precisa chamar a rota `POST http://back.localhost/api/v1/auth/login`, com os parâmetros:
```
{
    "email": "mmh@gmail.com",
    "senha": "admin123"
}
```
- Para chamar a rota de refresh token, basta chamar a rota `GET http://back.localhost/api/v1/auth/refresh`, passando o header `Authorization: Bearer <token>`.

## Cenário de teste

**1) Enviar uma requisição a uma rota autenticada (por exemplo, chamar a rota `GET /api/v1/parceiros`), sem passar um access token.**
Resultado esperado: a rota retornar o status 401 (unauthorized)

**2) Enviar uma requisição a uma rota autenticada passando um token válido, obtido pela rota `POST /api/v1/auth/login`.**
Resultado esperado: a rota retornar um status diferente de 401.

**3) Chamar a rota `GET /api/v1/auth/refresh` passando o token válido, gerado no passo anterior.**
Resultado esperado: a rota retornar o status 200 e retornar um novo access token.

**4) Chamar uma rota autenticada, passando o token gerado no passo 2 (que foi invalidado no passo anterior).**
Resultado esperado: a rota retornar o status 401, já que o token não é mais válido porque foi feito um refresh.

**5) Chamar uma rota autenticada, passando o token gerado no passo 3.**
Resultado esperado: a rota retornar um status diferente de 401 e ela finalizar sem erros.

**6) Chamar várias rotas autenticadas usando o mesmo token obtido no passo 3.**
Resultado esperado: todas as rotas devem retornar um status diferente de 401.