### PR TITLE
Remover obrigatoriedade do campo zona_id

### DIFF
--- a/app/Http/Requests/Beneficiario/AtualizarBeneficiarioRequest.php
+++ b/app/Http/Requests/Beneficiario/AtualizarBeneficiarioRequest.php
@@ -65,7 +65,7 @@ class AtualizarBeneficiarioRequest extends FormRequest
             'enderecos' => 'required|array|min:1',
             'enderecos.*.endereco' => 'required|max:255',
             'enderecos.*.bairro_id' => 'required|exists:bairros,id',
-            'enderecos.*.zona_id' => 'required|exists:zonas,id',
+            'enderecos.*.zona_id' => 'nullable|exists:zonas,id',
             'enderecos.*.ponto_referencia' => 'nullable',
             'enderecos.*.cep' => 'required|digits:8',
             'enderecos.*.cidade_id' => 'required|exists:cidades,id',

--- a/app/Http/Requests/Beneficiario/CriarBeneficiarioRequest.php
+++ b/app/Http/Requests/Beneficiario/CriarBeneficiarioRequest.php
@@ -65,7 +65,7 @@ class CriarBeneficiarioRequest extends FormRequest
             'enderecos' => 'required|array|min:1',
             'enderecos.*.endereco' => 'required|max:255',
             'enderecos.*.bairro_id' => 'required|exists:bairros,id',
-            'enderecos.*.zona_id' => 'required|exists:zonas,id',
+            'enderecos.*.zona_id' => 'nullable|exists:zonas,id',
             'enderecos.*.ponto_referencia' => 'nullable',
             'enderecos.*.cep' => 'required|digits:8',
             'enderecos.*.cidade_id' => 'required|exists:cidades,id',


### PR DESCRIPTION
## Descrição

O campo "zona_id" é nullable no banco de dados e essa opção não ficará visível para o usuário preencher na página. Portanto, ele terá que ser nullable na rota.

## Como testar esta PR

- Faça uma chamada para a rota `POST /api/v1/beneficiarios` ou `PUT /api/v1/beneficiarios/<id>`, não passando o campo `zona_id` ou passando-o com o valor `null`. Espera-se que a rota seja executada sem erros.