### PR TITLE
Remover configurações de pre-flight do Nginx

### DIFF
--- a/.infra/php-fpm/default.conf
+++ b/.infra/php-fpm/default.conf
@@ -9,21 +9,6 @@ server {
     root /var/www/public;
 
     location ~ \.php$ {
-        if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            #
-            # Custom headers and headers various browsers *should* be OK with but aren't
-            #
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-            #
-            # Tell client that this pre-flight info is valid for 20 days
-            #
-            add_header 'Access-Control-Max-Age' 1728000;
-            add_header 'Content-Type' 'text/plain; charset=utf-8';
-            add_header 'Content-Length' 0;
-            return 204;
-        }
         try_files $uri = 404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php-upstream;
@@ -34,21 +19,6 @@ server {
     }
 
     location / {
-        if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
-            #
-            # Custom headers and headers various browsers *should* be OK with but aren't
-            #
-            add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range';
-            #
-            # Tell client that this pre-flight info is valid for 20 days
-            #
-            add_header 'Access-Control-Max-Age' 1728000;
-            add_header 'Content-Type' 'text/plain; charset=utf-8';
-            add_header 'Content-Length' 0;
-            return 204;
-        }
         try_files $uri $uri/ /index.php?$query_string;
         gzip_static on;
     }


### PR DESCRIPTION
## Descrição

Quando uma requisição é feita de um domínio diferente do domínio do back-end, o client envia uma requisição de pre-flight, para pedir permissão para solicitar um recurso do back-end.

No Laravel, usamos um pacote que facilita o gerenciamento de CORS. Porém, as requisições do front não estavam chegando nele, porque tinha sido feita uma configuração no Nginx para fazer o pre-flight.

Como isso já é feito pelo back-end, vamos simplesmente remover essa configuração do lado do Nginx.