### PR TITLE
Adicionar suporte a permissão de chamada as rotas

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,7 @@ class User extends Authenticatable implements JWTSubject
                 'nome' => $this->pessoa->nome,
                 'email' => $this->email,
                 'status' => $this->statusParse,
+                'perfis' => implode(',', array_column($this->perfis->toArray(), 'perfil')),
                 'criado' => $this->created_at->format('d/m/Y'),
             ]
         ];


### PR DESCRIPTION
## Descrição

Adicionar lógica para permitir que um usuário logado só consiga acessar as rotas que ele tem permissão.

Com essa alteração, um usuário com o perfil "parceiro" não pode acessar uma rota de criação de outro parceiro, pois isso é uma funcionalidade do operador do Codese, por exemplo.

## Cenário de Teste

- Chamar a rota de autenticação `/api/v1/auth/login` e obter um token. Verifique se o campo perfis está sendo retornado no token JWT, acessando a página [jwt.io](https://jwt.io/) e inserindo o seu token.

**1) Testar uma rota que o usuário tenha permissão de acesso:**
- Resultado esperado: você conseguir acessar a rota sem problemas.

**2) Testar uma rota que o usuário não tenha permissão de acesso:**
- Resultado esperado: a rota vai retornar o status 401.
- 