### PR TITLE
Adicionar nova rota para retornar parceiros

### DIFF
--- a/app/Http/Controllers/ParceiroController.php
+++ b/app/Http/Controllers/ParceiroController.php
@@ -89,6 +89,31 @@ class ParceiroController extends Controller
     }
 
     /**
+     * Listar Básico
+     *
+     * Endpoint para buscar o ID e nome de todos os parceiros.
+     * Essa rota será usada especialmente na página de Beneficiários, quando o usuário logado
+     * for Admin ou Codese.
+     *
+     * @authenticated
+     *
+     * @responseFile 200 responses/ParceiroController/get.200.json
+     * @responseFile 500 responses/ParceiroController/internalServerError.500.json
+     */
+    public function basic(Request $request): JsonResponse
+    {
+        $resultado = $this->parceiroService->basic($request);
+
+        $resource = new ParceiroResource(
+            $resultado['data'] ??= null,
+            $resultado['success'],
+            $resultado['message'],
+        );
+
+        return $resource->response()->setStatusCode($resultado['code']);
+    }
+
+    /**
      * Criar
      *
      * Endpoint para inserir uma nova instituição parceira no sistema.

--- a/app/Services/ParceiroService.php
+++ b/app/Services/ParceiroService.php
@@ -56,6 +56,28 @@ class ParceiroService
         return $resultado;
     }
 
+    public function basic(Request $request): array
+    {
+        try {
+            $parceiros = $this->parceiro->get(['id', 'nome']);
+
+            $resultado = [
+                'success' => true,
+                'data' => $parceiros->makeHidden(['telefones', 'enderecos']),
+                'message' => 'Parceiros obtidos com sucesso!',
+                'code' => HttpStatus::OK,
+            ];
+        } catch (Exception $e) {
+            $resultado = [
+                'success' => false,
+                'message' => ApiError::erroInesperado($e->getMessage()),
+                'code' => HttpStatus::INTERNAL_SERVER_ERROR,
+            ];
+        }
+
+        return $resultado;
+    }
+
     public function getParceiroByCpfOrCnpj(string $cpfOrCnpj)
     {
         return Parceiro::where('cpf_cnpj', '=', $cpfOrCnpj)->first();

--- a/resources/docs/source/.compare.md
+++ b/resources/docs/source/.compare.md
@@ -1057,22 +1057,22 @@ let body = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1113,22 +1113,22 @@ $response = $client->post(
             'email' => 'fulano@tal.com',
             'data_nascimento' => '1990-01-01',
             'trabalho' => 'Trabalhador Autônomo',
-            'esta_desempregado' => true,
-            'estado_civil_id' => 8,
+            'esta_desempregado' => false,
+            'estado_civil_id' => 9,
             'nome_conjuge' => 'Carolina Novais.',
             'cpf_conjuge' => '10987654321',
             'total_residentes' => 4,
-            'situacao_moradia' => 'a',
+            'situacao_moradia' => 'maxime',
             'renda_mensal' => 1000.0,
-            'gostaria_montar_negocio' => false,
+            'gostaria_montar_negocio' => true,
             'gostaria_participar_cursos' => false,
-            'tipo_curso' => 'debitis',
+            'tipo_curso' => 'animi',
             'concorda_informacoes_verdadeiras' => false,
             'data_submissao' => '2020-05-01 10:11:12',
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'in',
+                    'tipo' => 'non',
                 ],
             ],
             'enderecos' => [
@@ -1160,22 +1160,22 @@ payload = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1202,7 +1202,7 @@ curl -X POST \
     "http://localhost/api/v1/beneficiarios" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"a","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":false,"tipo_curso":"debitis","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"in"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":false,"estado_civil_id":9,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"maxime","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":false,"tipo_curso":"animi","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"non"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -1315,21 +1315,21 @@ let body = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1371,21 +1371,21 @@ $response = $client->put(
             'data_nascimento' => '1990-01-01',
             'trabalho' => 'Trabalhador Autônomo',
             'esta_desempregado' => true,
-            'estado_civil_id' => 4,
+            'estado_civil_id' => 8,
             'nome_conjuge' => 'Carolina Novais.',
             'cpf_conjuge' => '10987654321',
             'total_residentes' => 4,
-            'situacao_moradia' => 'id',
+            'situacao_moradia' => 'architecto',
             'renda_mensal' => 1000.0,
-            'gostaria_montar_negocio' => true,
+            'gostaria_montar_negocio' => false,
             'gostaria_participar_cursos' => true,
-            'tipo_curso' => 'saepe',
+            'tipo_curso' => 'repellendus',
             'concorda_informacoes_verdadeiras' => false,
             'data_submissao' => '2020-05-01 10:11:12',
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'nihil',
+                    'tipo' => 'porro',
                 ],
             ],
             'enderecos' => [
@@ -1418,21 +1418,21 @@ payload = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1459,7 +1459,7 @@ curl -X PUT \
     "http://localhost/api/v1/beneficiarios/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":4,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"id","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":true,"tipo_curso":"saepe","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"nihil"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"architecto","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":true,"tipo_curso":"repellendus","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"porro"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -1985,6 +1985,144 @@ Parameter | Status | Description
 
 <!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
 
+<!-- START_5b7e578c57cc0e59c7b0a6653587ed4b -->
+## Listar Básico
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar o ID e nome de todos os parceiros.
+Essa rota será usada especialmente na página de Beneficiários, quando o usuário logado
+for Admin ou Codese.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/basico"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros/basico',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/basico'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros/basico" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros/basico`
+
+
+<!-- END_5b7e578c57cc0e59c7b0a6653587ed4b -->
+
 <!-- START_a072594af821ade9e7ce15d71dbe9460 -->
 ## Buscar
 
@@ -2161,7 +2299,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vitae"
+            "tipo": "mollitia"
         }
     ],
     "enderecos": [
@@ -2202,7 +2340,7 @@ $response = $client->post(
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'vitae',
+                    'tipo' => 'mollitia',
                 ],
             ],
             'enderecos' => [
@@ -2234,7 +2372,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vitae"
+            "tipo": "mollitia"
         }
     ],
     "enderecos": [
@@ -2260,7 +2398,7 @@ curl -X POST \
     "http://localhost/api/v1/parceiros" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"vitae"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"mollitia"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -2358,7 +2496,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2399,7 +2537,7 @@ $response = $client->put(
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'vel',
+                    'tipo' => 'placeat',
                 ],
             ],
             'enderecos' => [
@@ -2431,7 +2569,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2457,7 +2595,7 @@ curl -X PUT \
     "http://localhost/api/v1/parceiros/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"vel"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"placeat"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 

--- a/resources/docs/source/index.md
+++ b/resources/docs/source/index.md
@@ -1057,22 +1057,22 @@ let body = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1113,22 +1113,22 @@ $response = $client->post(
             'email' => 'fulano@tal.com',
             'data_nascimento' => '1990-01-01',
             'trabalho' => 'Trabalhador Autônomo',
-            'esta_desempregado' => true,
-            'estado_civil_id' => 8,
+            'esta_desempregado' => false,
+            'estado_civil_id' => 9,
             'nome_conjuge' => 'Carolina Novais.',
             'cpf_conjuge' => '10987654321',
             'total_residentes' => 4,
-            'situacao_moradia' => 'a',
+            'situacao_moradia' => 'maxime',
             'renda_mensal' => 1000.0,
-            'gostaria_montar_negocio' => false,
+            'gostaria_montar_negocio' => true,
             'gostaria_participar_cursos' => false,
-            'tipo_curso' => 'debitis',
+            'tipo_curso' => 'animi',
             'concorda_informacoes_verdadeiras' => false,
             'data_submissao' => '2020-05-01 10:11:12',
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'in',
+                    'tipo' => 'non',
                 ],
             ],
             'enderecos' => [
@@ -1160,22 +1160,22 @@ payload = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1202,7 +1202,7 @@ curl -X POST \
     "http://localhost/api/v1/beneficiarios" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"a","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":false,"tipo_curso":"debitis","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"in"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":false,"estado_civil_id":9,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"maxime","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":false,"tipo_curso":"animi","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"non"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -1315,21 +1315,21 @@ let body = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1371,21 +1371,21 @@ $response = $client->put(
             'data_nascimento' => '1990-01-01',
             'trabalho' => 'Trabalhador Autônomo',
             'esta_desempregado' => true,
-            'estado_civil_id' => 4,
+            'estado_civil_id' => 8,
             'nome_conjuge' => 'Carolina Novais.',
             'cpf_conjuge' => '10987654321',
             'total_residentes' => 4,
-            'situacao_moradia' => 'id',
+            'situacao_moradia' => 'architecto',
             'renda_mensal' => 1000.0,
-            'gostaria_montar_negocio' => true,
+            'gostaria_montar_negocio' => false,
             'gostaria_participar_cursos' => true,
-            'tipo_curso' => 'saepe',
+            'tipo_curso' => 'repellendus',
             'concorda_informacoes_verdadeiras' => false,
             'data_submissao' => '2020-05-01 10:11:12',
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'nihil',
+                    'tipo' => 'porro',
                 ],
             ],
             'enderecos' => [
@@ -1418,21 +1418,21 @@ payload = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1459,7 +1459,7 @@ curl -X PUT \
     "http://localhost/api/v1/beneficiarios/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":4,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"id","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":true,"tipo_curso":"saepe","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"nihil"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"architecto","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":true,"tipo_curso":"repellendus","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"porro"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 
@@ -1985,6 +1985,144 @@ Parameter | Status | Description
 
 <!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
 
+<!-- START_5b7e578c57cc0e59c7b0a6653587ed4b -->
+## Listar Básico
+
+<br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar o ID e nome de todos os parceiros.
+Essa rota será usada especialmente na página de Beneficiários, quando o usuário logado
+for Admin ou Codese.
+
+> Example request:
+
+```javascript
+const url = new URL(
+    "http://localhost/api/v1/parceiros/basico"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response => response.json())
+    .then(json => console.log(json));
+```
+
+```php
+
+$client = new \GuzzleHttp\Client();
+$response = $client->get(
+    'http://localhost/api/v1/parceiros/basico',
+    [
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+        ],
+    ]
+);
+$body = $response->getBody();
+print_r(json_decode((string) $body));
+```
+
+```python
+import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/basico'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()
+```
+
+```bash
+curl -X GET \
+    -G "http://localhost/api/v1/parceiros/basico" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"
+```
+
+
+> Example response (200):
+
+```json
+{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}
+```
+> Example response (500):
+
+```json
+{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}
+```
+
+### HTTP Request
+`GET api/v1/parceiros/basico`
+
+
+<!-- END_5b7e578c57cc0e59c7b0a6653587ed4b -->
+
 <!-- START_a072594af821ade9e7ce15d71dbe9460 -->
 ## Buscar
 
@@ -2357,7 +2495,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2398,7 +2536,7 @@ $response = $client->put(
             'telefones' => [
                 [
                     'telefone' => 92991234567,
-                    'tipo' => 'vel',
+                    'tipo' => 'placeat',
                 ],
             ],
             'enderecos' => [
@@ -2430,7 +2568,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2456,7 +2594,7 @@ curl -X PUT \
     "http://localhost/api/v1/parceiros/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"vel"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"placeat"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 
 ```
 

--- a/resources/views/apidoc/index.blade.php
+++ b/resources/views/apidoc/index.blade.php
@@ -1061,22 +1061,22 @@ let body = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1114,22 +1114,22 @@ $response = $client-&gt;post(
             'email' =&gt; 'fulano@tal.com',
             'data_nascimento' =&gt; '1990-01-01',
             'trabalho' =&gt; 'Trabalhador Autônomo',
-            'esta_desempregado' =&gt; true,
-            'estado_civil_id' =&gt; 8,
+            'esta_desempregado' =&gt; false,
+            'estado_civil_id' =&gt; 9,
             'nome_conjuge' =&gt; 'Carolina Novais.',
             'cpf_conjuge' =&gt; '10987654321',
             'total_residentes' =&gt; 4,
-            'situacao_moradia' =&gt; 'a',
+            'situacao_moradia' =&gt; 'maxime',
             'renda_mensal' =&gt; 1000.0,
-            'gostaria_montar_negocio' =&gt; false,
+            'gostaria_montar_negocio' =&gt; true,
             'gostaria_participar_cursos' =&gt; false,
-            'tipo_curso' =&gt; 'debitis',
+            'tipo_curso' =&gt; 'animi',
             'concorda_informacoes_verdadeiras' =&gt; false,
             'data_submissao' =&gt; '2020-05-01 10:11:12',
             'telefones' =&gt; [
                 [
                     'telefone' =&gt; 92991234567,
-                    'tipo' =&gt; 'in',
+                    'tipo' =&gt; 'non',
                 ],
             ],
             'enderecos' =&gt; [
@@ -1158,22 +1158,22 @@ payload = {
     "email": "fulano@tal.com",
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
-    "esta_desempregado": true,
-    "estado_civil_id": 8,
+    "esta_desempregado": false,
+    "estado_civil_id": 9,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "a",
+    "situacao_moradia": "maxime",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": false,
+    "gostaria_montar_negocio": true,
     "gostaria_participar_cursos": false,
-    "tipo_curso": "debitis",
+    "tipo_curso": "animi",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "in"
+            "tipo": "non"
         }
     ],
     "enderecos": [
@@ -1197,7 +1197,7 @@ response.json()</code></pre>
     "http://localhost/api/v1/beneficiarios" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"a","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":false,"tipo_curso":"debitis","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"in"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":false,"estado_civil_id":9,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"maxime","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":false,"tipo_curso":"animi","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"non"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 </code></pre>
 <blockquote>
 <p>Example response (201):</p>
@@ -1447,21 +1447,21 @@ let body = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1500,21 +1500,21 @@ $response = $client-&gt;put(
             'data_nascimento' =&gt; '1990-01-01',
             'trabalho' =&gt; 'Trabalhador Autônomo',
             'esta_desempregado' =&gt; true,
-            'estado_civil_id' =&gt; 4,
+            'estado_civil_id' =&gt; 8,
             'nome_conjuge' =&gt; 'Carolina Novais.',
             'cpf_conjuge' =&gt; '10987654321',
             'total_residentes' =&gt; 4,
-            'situacao_moradia' =&gt; 'id',
+            'situacao_moradia' =&gt; 'architecto',
             'renda_mensal' =&gt; 1000.0,
-            'gostaria_montar_negocio' =&gt; true,
+            'gostaria_montar_negocio' =&gt; false,
             'gostaria_participar_cursos' =&gt; true,
-            'tipo_curso' =&gt; 'saepe',
+            'tipo_curso' =&gt; 'repellendus',
             'concorda_informacoes_verdadeiras' =&gt; false,
             'data_submissao' =&gt; '2020-05-01 10:11:12',
             'telefones' =&gt; [
                 [
                     'telefone' =&gt; 92991234567,
-                    'tipo' =&gt; 'nihil',
+                    'tipo' =&gt; 'porro',
                 ],
             ],
             'enderecos' =&gt; [
@@ -1544,21 +1544,21 @@ payload = {
     "data_nascimento": "1990-01-01",
     "trabalho": "Trabalhador Aut\u00f4nomo",
     "esta_desempregado": true,
-    "estado_civil_id": 4,
+    "estado_civil_id": 8,
     "nome_conjuge": "Carolina Novais.",
     "cpf_conjuge": "10987654321",
     "total_residentes": 4,
-    "situacao_moradia": "id",
+    "situacao_moradia": "architecto",
     "renda_mensal": 1000,
-    "gostaria_montar_negocio": true,
+    "gostaria_montar_negocio": false,
     "gostaria_participar_cursos": true,
-    "tipo_curso": "saepe",
+    "tipo_curso": "repellendus",
     "concorda_informacoes_verdadeiras": false,
     "data_submissao": "2020-05-01 10:11:12",
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "nihil"
+            "tipo": "porro"
         }
     ],
     "enderecos": [
@@ -1582,7 +1582,7 @@ response.json()</code></pre>
     "http://localhost/api/v1/beneficiarios/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":4,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"id","renda_mensal":1000,"gostaria_montar_negocio":true,"gostaria_participar_cursos":true,"tipo_curso":"saepe","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"nihil"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"parceiro_id":1,"nome":"Machado de Assis","cpf":"12345678901","email":"fulano@tal.com","data_nascimento":"1990-01-01","trabalho":"Trabalhador Aut\u00f4nomo","esta_desempregado":true,"estado_civil_id":8,"nome_conjuge":"Carolina Novais.","cpf_conjuge":"10987654321","total_residentes":4,"situacao_moradia":"architecto","renda_mensal":1000,"gostaria_montar_negocio":false,"gostaria_participar_cursos":true,"tipo_curso":"repellendus","concorda_informacoes_verdadeiras":false,"data_submissao":"2020-05-01 10:11:12","telefones":[{"telefone":92991234567,"tipo":"porro"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"zona_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 </code></pre>
 <blockquote>
 <p>Example response (200):</p>
@@ -2224,6 +2224,124 @@ response.json()</code></pre>
 </tbody>
 </table>
 <!-- END_0d4dfb28e77c127afb29ac9f5077f22f -->
+<!-- START_5b7e578c57cc0e59c7b0a6653587ed4b -->
+<h2>Listar Básico</h2>
+<p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
+Endpoint para buscar o ID e nome de todos os parceiros.
+Essa rota será usada especialmente na página de Beneficiários, quando o usuário logado
+for Admin ou Codese.</p>
+<blockquote>
+<p>Example request:</p>
+</blockquote>
+<pre><code class="language-javascript">const url = new URL(
+    "http://localhost/api/v1/parceiros/basico"
+);
+
+let headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+};
+
+fetch(url, {
+    method: "GET",
+    headers: headers,
+})
+    .then(response =&gt; response.json())
+    .then(json =&gt; console.log(json));</code></pre>
+<pre><code class="language-php">
+$client = new \GuzzleHttp\Client();
+$response = $client-&gt;get(
+    'http://localhost/api/v1/parceiros/basico',
+    [
+        'headers' =&gt; [
+            'Content-Type' =&gt; 'application/json',
+            'Accept' =&gt; 'application/json',
+        ],
+    ]
+);
+$body = $response-&gt;getBody();
+print_r(json_decode((string) $body));</code></pre>
+<pre><code class="language-python">import requests
+import json
+
+url = 'http://localhost/api/v1/parceiros/basico'
+headers = {
+  'Content-Type': 'application/json',
+  'Accept': 'application/json'
+}
+response = requests.request('GET', url, headers=headers)
+response.json()</code></pre>
+<pre><code class="language-bash">curl -X GET \
+    -G "http://localhost/api/v1/parceiros/basico" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json"</code></pre>
+<blockquote>
+<p>Example response (200):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "current_page": 1,
+    "data": [
+        {
+            "id": 8,
+            "nome": "Boa Ação",
+            "email": "contato@boacao.com.br",
+            "tipo_pessoa": {
+                "id": 9,
+                "tipo_pessoa": "pj",
+                "cpf_cnpj": "38797937000102"
+            },
+            "telefones": [
+                {
+                    "id": 1,
+                    "telefone": "9236445874",
+                    "tipo": 2
+                }
+            ],
+            "enderecos": [
+                {
+                    "id": 3,
+                    "endereco": "Rua Açaí",
+                    "ponto_referencia": null,
+                    "cep": "69068447",
+                    "cidade": {
+                        "nome": "Manaus",
+                        "estado": {
+                            "uf": "AM",
+                            "nome": "Amazonas"
+                        }
+                    },
+                    "bairro": {
+                        "nome": "Raiz"
+                    }
+                }
+            ]
+        }
+    ],
+    "first_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "from": null,
+    "last_page": 1,
+    "last_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "next_page_url": null,
+    "path": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "per_page": 6,
+    "prev_page_url": "http:\/\/back.localhost\/api\/v1\/parceiros",
+    "to": null,
+    "total": 0,
+    "message": "Parceiro obtido com sucesso!",
+    "success": true
+}</code></pre>
+<blockquote>
+<p>Example response (500):</p>
+</blockquote>
+<pre><code class="language-json">{
+    "data": [],
+    "message": "Erro #1: Um erro inesperado ocorreu.",
+    "success": false,
+    "url": "http:\/\/back.localhost\/api\/v1\/parceiros"
+}</code></pre>
+<h3>HTTP Request</h3>
+<p><code>GET api/v1/parceiros/basico</code></p>
+<!-- END_5b7e578c57cc0e59c7b0a6653587ed4b -->
 <!-- START_a072594af821ade9e7ce15d71dbe9460 -->
 <h2>Buscar</h2>
 <p><br><small style="padding: 1px 9px 2px;font-weight: bold;white-space: nowrap;color: #ffffff;-webkit-border-radius: 9px;-moz-border-radius: 9px;border-radius: 9px;background-color: #3a87ad;">Requires authentication</small>
@@ -2638,7 +2756,7 @@ let body = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2676,7 +2794,7 @@ $response = $client-&gt;put(
             'telefones' =&gt; [
                 [
                     'telefone' =&gt; 92991234567,
-                    'tipo' =&gt; 'vel',
+                    'tipo' =&gt; 'placeat',
                 ],
             ],
             'enderecos' =&gt; [
@@ -2705,7 +2823,7 @@ payload = {
     "telefones": [
         {
             "telefone": 92991234567,
-            "tipo": "vel"
+            "tipo": "placeat"
         }
     ],
     "enderecos": [
@@ -2728,7 +2846,7 @@ response.json()</code></pre>
     "http://localhost/api/v1/parceiros/1" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
-    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"vel"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
+    -d '{"nome":"Manaus+Humana","email":"fulano@tal.com","cnpj":"13245678901234","cpf":"12345678901","telefones":[{"telefone":92991234567,"tipo":"placeat"}],"enderecos":[{"endereco":"Rua da paz, 150","bairro_id":1,"cep":"\"69061000\"","ponto_referencia":"\"INPA\"","cidade_id":1}]}'
 </code></pre>
 <blockquote>
 <p>Example response (200):</p>

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ Route::prefix('v1')->group(function () {
 
     Route::prefix('parceiros')->group(function () {
         Route::get('/', 'ParceiroController@get')->name('parceiros.get');
+        Route::get('/basico', 'ParceiroController@basic')->name('parceiros.basic');
         Route::get('/{id}', 'ParceiroController@find')->name('parceiros.getbyid');
         Route::post('/', 'ParceiroController@store')->name('parceiros.save');
         Route::put('/{id}', 'ParceiroController@update')->name('parceiros.update');

--- a/storage/responses/ParceiroController/basic.200.json
+++ b/storage/responses/ParceiroController/basic.200.json
@@ -1,0 +1,14 @@
+{
+    "data": [
+        {
+            "id": 1,
+            "nome": "Boa Ação",
+        },
+        {
+            "id": 2,
+            "nome": "Amanhã Melhor",
+        }
+    ],
+    "message": "Parceiros obtidos com sucesso!",
+    "success": true
+}


### PR DESCRIPTION
## Descrição

Adicionar nova rota para retornar apenas o ID e o nome de todos os parceiros, sem fazer paginação.

Essa rota será usada na página de inserção de beneficiários. Porém, ela só será visível quando o usuário logado for Admin ou Codese.

## Cenário de Teste

- Chamar a rota `/api/v1/parceiros/basico`, sendo que o usuário precisa estar logado como Admin ou Codese. Espera-se a rota retornar apenas o ID e o nome de todos os parceiros cadastrados.